### PR TITLE
build: dual ESM/CJS output via tsup

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,22 @@
   "description": "A functional typescript implementation of the PCG family random number generators",
   "sideEffects": false,
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "files": [
-    "/dist/",
-    "!/dist/**/__tests__/*.js"
+    "/dist/"
   ],
   "repository": "https://github.com/philihp/pcg",
   "contributors": [
@@ -15,7 +28,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsup",
     "lint": "eslint --ext .ts src",
     "prepare": "husky install && npm run build",
     "test": "jest",
@@ -43,6 +56,7 @@
     "lint-staged": "17.0.4",
     "prettier": "3.8.3",
     "ts-jest": "29.4.9",
+    "tsup": "^8.5.1",
     "typescript": "5.9.3"
   },
   "lint-staged": {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts"]
-}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  outDir: 'dist',
+  target: 'node20',
+})


### PR DESCRIPTION
## Summary

- Replace the tsc-based build with [tsup](https://tsup.egoist.dev/) (esbuild under the hood) so the package ships both CJS and ESM
- `dist/index.js` (CJS) + `dist/index.mjs` (ESM) + matching `.d.ts` / `.d.mts`
- Add an `exports` map so Node resolves the right entry per `import` vs `require`
- Keep `main`/`module`/`types` for older toolchains
- Remove the now-unused `tsconfig.build.json`

Verified locally that both formats import and produce identical output:
```
$ node test.cjs && node test.mjs
CJS: 83
ESM: 83
```

## Test plan
- [x] `npm run build` produces dist/index.js, dist/index.mjs, dist/index.d.ts, dist/index.d.mts
- [x] `node` can `require('pcg')` and `import 'pcg'` and both work
- [x] `npm test` (22/22)
- [x] `npm run lint` (0 errors)

https://claude.ai/code/session_012YQhL9rir4bAoQ6z5rJTr1

---
_Generated by [Claude Code](https://claude.ai/code/session_012YQhL9rir4bAoQ6z5rJTr1)_