### PR TITLE
Cherry-pick airbreather's f1ef9cc: better typing for createPcg32

### DIFF
--- a/src/createPcg.ts
+++ b/src/createPcg.ts
@@ -71,17 +71,15 @@ export const randomList = curry((length, rng, initPcg): [number, PCGState][] =>
   scan(([, lastPcg]) => rng(lastPcg), rng(initPcg), new Array(length - 1))
 )
 
-export type CreatePcgOptions = {
-  streamScheme?: StreamScheme
-  outputFnType?: OutputFnType
-}
-
-export default curry(
+type LongLike = Long | number | bigint | string | { low: number; high: number; unsigned: boolean }
+export default ({ numOutputBits, multiplier, increment, outputFns }: PCGConfig) =>
   (
-    { numOutputBits, multiplier, increment, outputFns }: PCGConfig,
-    { streamScheme = pcgDefaultStreamScheme, outputFnType = pcgDefaultOutputFnType }: CreatePcgOptions,
-    initState: number | Long,
-    initStreamId: number | Long
+    {
+      streamScheme = pcgDefaultStreamScheme,
+      outputFnType = pcgDefaultOutputFnType,
+    }: { streamScheme?: StreamScheme; outputFnType?: OutputFnType },
+    initState: LongLike,
+    initStreamId: LongLike
   ): PCGState => {
     const streamId = Long.fromValue(initStreamId).toUnsigned().shl(1).or(1)
 
@@ -98,4 +96,3 @@ export default curry(
       getOutput: outputFns[outputFnType],
     })
   }
-)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import { OutputFnType } from './types'
 import createPcg from './createPcg'
 
 export { stepState, nextState, prevState, randomInt, randomList } from './createPcg'
-export type { CreatePcgOptions } from './createPcg'
 export { OutputFnType, StreamScheme } from './types'
 export type { OutputFn, PCGConfig, PCGState, SchemeFn } from './types'
 


### PR DESCRIPTION
## Summary

Cherry-picks [`f1ef9cc`](https://github.com/philihp/pcg/commit/f1ef9ccaef213758509746eb0039b3d5c293682e) ("Better typing for createPcg32") by @airbreather, referenced in #240.

Compared to the previously merged #318:
- Drops the `curry()` wrapper on the default export entirely (rather than typing it through `Curry<>`).
- Widens the `initState` / `initStreamId` parameters to a `LongLike` union (`Long | number | bigint | string | { low; high; unsigned }`) — anything `Long.fromValue` accepts.

### Conflict resolution

The cherry-pick conflicted with #318's typed-curry approach in the same region of `src/createPcg.ts`. I resolved by taking f1ef9cc's version verbatim and removed the now-orphaned `export type { CreatePcgOptions }` re-export from `src/index.ts` (the type was introduced in #318 and no longer exists after this cherry-pick).

### Note

This is a behavior change for any consumer relying on Ramda-style partial application of `createPcg32` (e.g. `createPcg32({})(42)(54)`). The full-arg form `createPcg32({}, 42, 54)` used in the tests and README is unaffected.

## Test plan
- [x] `npm run build`
- [x] `npm test` (22/22)
- [x] `npm run lint` (0 errors)

https://claude.ai/code/session_012YQhL9rir4bAoQ6z5rJTr1

---
_Generated by [Claude Code](https://claude.ai/code/session_012YQhL9rir4bAoQ6z5rJTr1)_