### PR TITLE
types: round out public typings; re-affirm #240

### DIFF
--- a/src/createPcg.ts
+++ b/src/createPcg.ts
@@ -1,7 +1,7 @@
 import Long from 'long'
 import { curry, scan } from 'ramda'
 import { pcgDefaultOutputFnType, pcgDefaultStreamScheme } from './defaults'
-import { OutputFnType, PCGConfig, PCGState, SchemeFn, StreamScheme } from './types'
+import { CreatePcg, CreatePcgOptions, LongLike, PCGConfig, PCGState, RandomFn, SchemeFn, StreamScheme } from './types'
 
 /* Multi-step advance functions (jump-ahead, jump-back)
  *
@@ -67,28 +67,17 @@ export const randomInt = curry((min: number, max: number, pcg: PCGState): [numbe
   return [n.mod(bound).add(min).toNumber(), nextPcg]
 })
 
-export type RandomFn<T> = (pcg: PCGState) => [T, PCGState]
-
+// Manually-typed curried overloads — ramda's Curry<> helper erases generics.
 interface RandomListFn {
   <T>(length: number, rng: RandomFn<T>, initPcg: PCGState): [T, PCGState][]
   <T>(length: number, rng: RandomFn<T>): (initPcg: PCGState) => [T, PCGState][]
   <T>(length: number): (rng: RandomFn<T>, initPcg: PCGState) => [T, PCGState][]
-  <T>(length: number): (rng: RandomFn<T>) => (initPcg: PCGState) => [T, PCGState][]
 }
 
 export const randomList: RandomListFn = curry(
   <T>(length: number, rng: RandomFn<T>, initPcg: PCGState): [T, PCGState][] =>
     scan(([, lastPcg]) => rng(lastPcg), rng(initPcg), new Array(length - 1))
 ) as RandomListFn
-
-export type LongLike = Long | number | bigint | string | { low: number; high: number; unsigned: boolean }
-
-export type CreatePcgOptions = {
-  streamScheme?: StreamScheme
-  outputFnType?: OutputFnType
-}
-
-export type CreatePcg = (options: CreatePcgOptions, initState: LongLike, initStreamId: LongLike) => PCGState
 
 export default ({ numOutputBits, multiplier, increment, outputFns }: PCGConfig): CreatePcg =>
   (

--- a/src/createPcg.ts
+++ b/src/createPcg.ts
@@ -67,17 +67,32 @@ export const randomInt = curry((min: number, max: number, pcg: PCGState): [numbe
   return [n.mod(bound).add(min).toNumber(), nextPcg]
 })
 
-export const randomList = curry((length, rng, initPcg): [number, PCGState][] =>
-  scan(([, lastPcg]) => rng(lastPcg), rng(initPcg), new Array(length - 1))
-)
+export type RandomFn<T> = (pcg: PCGState) => [T, PCGState]
 
-type LongLike = Long | number | bigint | string | { low: number; high: number; unsigned: boolean }
-export default ({ numOutputBits, multiplier, increment, outputFns }: PCGConfig) =>
+interface RandomListFn {
+  <T>(length: number, rng: RandomFn<T>, initPcg: PCGState): [T, PCGState][]
+  <T>(length: number, rng: RandomFn<T>): (initPcg: PCGState) => [T, PCGState][]
+  <T>(length: number): (rng: RandomFn<T>, initPcg: PCGState) => [T, PCGState][]
+  <T>(length: number): (rng: RandomFn<T>) => (initPcg: PCGState) => [T, PCGState][]
+}
+
+export const randomList: RandomListFn = curry(
+  <T>(length: number, rng: RandomFn<T>, initPcg: PCGState): [T, PCGState][] =>
+    scan(([, lastPcg]) => rng(lastPcg), rng(initPcg), new Array(length - 1))
+) as RandomListFn
+
+export type LongLike = Long | number | bigint | string | { low: number; high: number; unsigned: boolean }
+
+export type CreatePcgOptions = {
+  streamScheme?: StreamScheme
+  outputFnType?: OutputFnType
+}
+
+export type CreatePcg = (options: CreatePcgOptions, initState: LongLike, initStreamId: LongLike) => PCGState
+
+export default ({ numOutputBits, multiplier, increment, outputFns }: PCGConfig): CreatePcg =>
   (
-    {
-      streamScheme = pcgDefaultStreamScheme,
-      outputFnType = pcgDefaultOutputFnType,
-    }: { streamScheme?: StreamScheme; outputFnType?: OutputFnType },
+    { streamScheme = pcgDefaultStreamScheme, outputFnType = pcgDefaultOutputFnType }: CreatePcgOptions,
     initState: LongLike,
     initStreamId: LongLike
   ): PCGState => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,8 @@ import { OutputFnType } from './types'
 import createPcg from './createPcg'
 
 export { stepState, nextState, prevState, randomInt, randomList } from './createPcg'
-export type { CreatePcg, CreatePcgOptions, LongLike, RandomFn } from './createPcg'
 export { OutputFnType, StreamScheme } from './types'
-export type { OutputFn, PCGConfig, PCGState, SchemeFn } from './types'
+export type { CreatePcg, CreatePcgOptions, LongLike, OutputFn, PCGConfig, PCGState, RandomFn, SchemeFn } from './types'
 
 export const createPcg32 = createPcg({
   numOutputBits: 32,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { OutputFnType } from './types'
 import createPcg from './createPcg'
 
 export { stepState, nextState, prevState, randomInt, randomList } from './createPcg'
+export type { CreatePcg, CreatePcgOptions, LongLike, RandomFn } from './createPcg'
 export { OutputFnType, StreamScheme } from './types'
 export type { OutputFn, PCGConfig, PCGState, SchemeFn } from './types'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,8 @@ export enum StreamScheme {
 
 export type SchemeFn = () => Long
 
+export type LongLike = Long | number | bigint | string | { low: number; high: number; unsigned: boolean }
+
 export type PCGConfig = {
   numOutputBits: number
   multiplier: Long
@@ -40,3 +42,12 @@ export type PCGState = {
   }
   getOutput: OutputFn
 }
+
+export type RandomFn<T> = (pcg: PCGState) => [T, PCGState]
+
+export type CreatePcgOptions = {
+  streamScheme?: StreamScheme
+  outputFnType?: OutputFnType
+}
+
+export type CreatePcg = (options: CreatePcgOptions, initState: LongLike, initStreamId: LongLike) => PCGState


### PR DESCRIPTION
## Summary

After #318 / #319 the originally reported `createPcg32` regression (#240) is fixed, but a couple of typing gaps remained. This PR closes them and re-verifies the issue against a fresh consumer build.

### Gaps addressed

- **`randomList` was completely untyped.** All three params (`length`, `rng`, `initPcg`) were inferred as `any`, so the return type degenerated to `[any, PCGState][]` and partial application gave back `any`. Now it's generic in `T` with a manually declared curried overload set, so `randomList(10, randomInt(0, 100), pcg)` resolves to `[number, PCGState][]`. (Ramda's `Curry<>` helper erases generic type parameters, so the overloads are typed by hand and the implementation is still `curry(...)` underneath.)
- **Helper types weren't exported.** Added `RandomFn<T>`, `LongLike`, `CreatePcg`, `CreatePcgOptions` to the public API so consumers can name them.
- **Inline literal types in the `createPcg` default export** are replaced with the named `CreatePcgOptions` / `LongLike` types.

### Issue #240 verification

```ts
import { createPcg32, randomInt, randomList, RandomFn, PCGState } from 'pcg'

// the exact pattern from the issue:
export const init = () => createPcg32({}, 42, 54)

// LongLike accepts bigint:
export const withBigint: PCGState = createPcg32({}, 42n, 54n)

// generics flow through randomList:
const u32: RandomFn<number> = randomInt(0, 2 ** 32 - 1)
export const list = randomList(10, u32, init())
```

Emitted `.d.ts`:
```ts
export declare const init: () => PCGState
export declare const withBigint: PCGState
export declare const list: [number, PCGState][]
```

No `any`, no portability errors, no `unknown`.

## Test plan
- [x] `npm run build`
- [x] `npm test` (22/22)
- [x] `npm run lint` (0 errors)
- [x] External consumer `.d.ts` resolves to precise types

https://claude.ai/code/session_012YQhL9rir4bAoQ6z5rJTr1

---
_Generated by [Claude Code](https://claude.ai/code/session_012YQhL9rir4bAoQ6z5rJTr1)_