### PR TITLE
chore: upgrade TypeScript to 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "prettier": "3.8.3",
     "ts-jest": "29.4.9",
     "tsup": "^8.5.1",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "ignoreDeprecations": "6.0",
+    "types": ["jest", "node"]
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
## Summary
- Bumped `typescript` from 5.9.3 to 6.0.3
- Added `ignoreDeprecations: "6.0"` for the inherited deprecated `baseUrl` option
- Added explicit `types: ["jest", "node"]` (TS 6 no longer auto-resolved them under nodenext for this config)

Other dependencies were already up-to-date. ESLint 10 was skipped because `eslint-plugin-import` does not yet support it (peer dep conflict).

## Test plan
- [x] `npm test` (22 tests pass)
- [x] `npm run build` (CJS, ESM, DTS all build)
- [x] `npm run lint` (no errors)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEwdiKN9NzTNuvNedgnyQk)_