### PR TITLE
chore: upgrade eslint to 9, migrate to flat config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,55 @@
+const js = require('@eslint/js')
+const tseslint = require('typescript-eslint')
+const importPlugin = require('eslint-plugin-import')
+const jestPlugin = require('eslint-plugin-jest')
+
+module.exports = [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+    },
+    plugins: {
+      import: importPlugin,
+    },
+    settings: {
+      'import/extensions': ['.js', '.ts'],
+      'import/parsers': {
+        '@typescript-eslint/parser': ['.ts', '.js'],
+      },
+      'import/resolver': {
+        typescript: {},
+        node: { extensions: ['.js', '.ts'] },
+      },
+    },
+    rules: {
+      'import/extensions': [
+        'error',
+        'ignorePackages',
+        { js: 'never', ts: 'never' },
+      ],
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '_',
+          varsIgnorePattern: '_',
+          caughtErrorsIgnorePattern: '_',
+        },
+      ],
+    },
+  },
+  {
+    files: ['src/**/__tests__/**/*.ts'],
+    plugins: { jest: jestPlugin },
+    rules: {
+      ...jestPlugin.configs.recommended.rules,
+    },
+  },
+  {
+    ignores: ['dist/**'],
+  },
+]

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsup",
-    "lint": "eslint --ext .ts src",
+    "lint": "eslint src",
     "prepare": "husky install && npm run build",
     "test": "jest",
     "test:coverage": "jest --coverage",
@@ -40,14 +40,12 @@
     "ramda": "0.32.0"
   },
   "devDependencies": {
-    "@philihp/eslint-config": "6.1.0",
+    "@eslint/js": "9.39.4",
     "@philihp/prettier-config": "1.0.0",
     "@tsconfig/node24": "24.0.4",
     "@types/jest": "30.0.0",
     "@types/ramda": "0.31.1",
-    "@typescript-eslint/eslint-plugin": "8.59.2",
-    "@typescript-eslint/parser": "8.59.2",
-    "eslint": "8.57.1",
+    "eslint": "9.39.4",
     "eslint-import-resolver-typescript": "4.4.4",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jest": "29.15.2",
@@ -57,11 +55,12 @@
     "prettier": "3.8.3",
     "ts-jest": "29.4.9",
     "tsup": "^8.5.1",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.59.2"
   },
   "lint-staged": {
     "src/**/*.ts": [
-      "eslint --ext .ts --fix"
+      "eslint --fix"
     ]
   },
   "jest": {
@@ -70,62 +69,5 @@
       "dist/"
     ]
   },
-  "prettier": "@philihp/prettier-config",
-  "eslintConfig": {
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "project": "./tsconfig.json"
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "extends": [
-      "@philihp",
-      "plugin:jest/recommended",
-      "plugin:@typescript-eslint/recommended"
-    ],
-    "settings": {
-      "react": {
-        "version": "18.2.0"
-      },
-      "import/extensions": [
-        ".js",
-        ".ts"
-      ],
-      "import/parsers": {
-        "@typescript-eslint/parser": [
-          ".ts",
-          ".js"
-        ]
-      },
-      "import/resolver": {
-        "typescript": {},
-        "node": {
-          "extensions": [
-            ".js",
-            ".ts"
-          ]
-        }
-      }
-    },
-    "rules": {
-      "import/extensions": [
-        "error",
-        "ignorePackages",
-        {
-          "js": "never",
-          "ts": "never"
-        }
-      ],
-      "@typescript-eslint/no-unused-vars": [
-        "warn",
-        {
-          "argsIgnorePattern": "_",
-          "varsIgnorePattern": "_",
-          "caughtErrorsIgnorePattern": "_"
-        }
-      ],
-      "jest/max-expects": "off"
-    }
-  }
+  "prettier": "@philihp/prettier-config"
 }


### PR DESCRIPTION
## Summary
- Upgrade `eslint` 8.57.1 → 9.39.4
- Migrate from `eslintConfig` in package.json to a flat `eslint.config.js`
- Drop `@philihp/eslint-config` (uses legacy eslintrc and pulls in plugins that are incompatible with ESLint 9 plugin resolution)
- Replace `@typescript-eslint/eslint-plugin` + `@typescript-eslint/parser` with the unified `typescript-eslint` package, add `@eslint/js`

The flat config retains the prior rules: `import/extensions` (ignorePackages, ts/js never), `@typescript-eslint/no-unused-vars` with `_` ignore patterns, and `eslint-plugin-jest` recommended on test files.

## Test plan
- [x] `npm install` (no peer-dep conflicts, 0 vulnerabilities)
- [x] `npm run lint` (4 pre-existing warnings, 0 errors)
- [x] `npm test` (22 tests pass)
- [x] `npm run build` (CJS, ESM, DTS all build)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEwdiKN9NzTNuvNedgnyQk)_