### PR TITLE
fix: allow randomInt bound equal to outputMaxRange

### DIFF
--- a/src/__tests__/createPcg32.test.ts
+++ b/src/__tests__/createPcg32.test.ts
@@ -112,6 +112,16 @@ describe('basic', () => {
     expect(() => randomInt(0, -1, pcg)).toThrow(RangeError)
   })
 
+  it('supports the full 32-bit output range (bound === 2^32)', () => {
+    expect.assertions(2)
+    const pcg = createPcg32({}, 42, 54)
+    const randomFullUint32 = randomInt(0, 2 ** 32)
+    // With bound === outputMaxRange, threshold is 0 and the raw output is
+    // returned unmodified, so this should match the first raw XSH_RR output.
+    expect(randomFullUint32(pcg)[0]).toBe(0xa15c02b7)
+    expect(() => randomInt(0, 2 ** 32 + 1, pcg)).toThrow(RangeError)
+  })
+
   it('can generate a list, with corresponding states', () => {
     expect.assertions(3)
     const advancedOptions = {}

--- a/src/createPcg.ts
+++ b/src/createPcg.ts
@@ -69,7 +69,7 @@ export const prevState = stepState(-1)
 
 const randomIntImpl = (min: number, max: number, pcg: PCGState): [number, PCGState] => {
   const bound = max - min
-  if (bound < 0 || bound >= pcg.algorithm.outputMaxRange) throw new RangeError()
+  if (bound < 0 || bound > pcg.algorithm.outputMaxRange) throw new RangeError()
 
   const threshold = (pcg.algorithm.outputMaxRange - bound) % bound
   const getOutput = pcg.getOutput


### PR DESCRIPTION
## Summary

Fixes #138. `randomInt` rejected `max - min === outputMaxRange` (e.g. `randomInt(0, 2 ** 32)`), so callers could only generate integers in `[0, 2^32 - 2]` rather than the full 32-bit range.

When `bound === outputMaxRange`, no rejection sampling is needed: `threshold` evaluates to `0`, every output is accepted, and `n % bound === n` (since `n < outputMaxRange`). The check is loosened from `>=` to `>`, which is the smallest possible fix.

## Test plan

- [x] Existing 22 tests still pass
- [x] New test verifies `randomInt(0, 2 ** 32)` succeeds and returns the raw 32-bit output (`0xa15c02b7` for the seed used elsewhere in the suite)
- [x] New test verifies `randomInt(0, 2 ** 32 + 1)` still throws `RangeError`

---
_Generated by [Claude Code](https://claude.ai/code/session_016tWD6HG5sKF1DXxxdv3rM4)_