### PR TITLE
feat: make PCGState JSON-serializable (#179)

### DIFF
--- a/src/__tests__/createPcg32.test.ts
+++ b/src/__tests__/createPcg32.test.ts
@@ -1,4 +1,4 @@
-import { createPcg32, nextState, prevState, randomInt, randomList } from '..'
+import { createPcg32, getOutput, nextState, prevState, randomInt, randomList } from '..'
 import { OutputFnType } from '../types'
 
 describe('basic', () => {
@@ -145,7 +145,7 @@ describe('basic', () => {
     for (let x = 0; x < 256; x++) {
       for (let y = 0; y < 256; y++) {
         const pcg = createPcg32({}, x, y)
-        expect(pcg.getOutput(pcg.state)).not.toBe(0)
+        expect(getOutput(pcg)).not.toBe(0)
       }
     }
   })

--- a/src/__tests__/serialize.test.ts
+++ b/src/__tests__/serialize.test.ts
@@ -1,0 +1,77 @@
+import { createPcg32, fromBigInt, nextState, randomInt, randomList, toBigInt } from '..'
+import { OutputFnType, PCGState, StreamScheme } from '../types'
+
+describe('serialize', () => {
+  it('round-trips the state through JSON.stringify/parse', () => {
+    expect.assertions(2)
+    const pcg = createPcg32({}, 42, 54)
+    const json = JSON.stringify(pcg)
+    const revived = JSON.parse(json) as PCGState
+    expect(revived).toStrictEqual(pcg)
+
+    const randomUint32 = randomInt(0, 2 ** 32 - 1)
+    expect(randomUint32(revived)[0]).toBe(randomUint32(pcg)[0])
+  })
+
+  it('continues a generation sequence after a serialization round-trip', () => {
+    expect.assertions(1)
+    const pcg = createPcg32({}, 42, 54)
+    const randomUint32 = randomInt(0, 2 ** 32 - 1)
+
+    const reference = randomList(6, randomUint32, pcg).map(([v]) => v)
+
+    // Generate the first 3, persist the state, then continue.
+    const firstThree = randomList(3, randomUint32, pcg)
+    const persisted = JSON.parse(JSON.stringify(firstThree[2][1])) as PCGState
+    const resumed = randomList(3, randomUint32, persisted).map(([v]) => v)
+
+    expect([...firstThree.map(([v]) => v), ...resumed]).toStrictEqual(reference)
+  })
+
+  it('state contains no functions and no bigints', () => {
+    expect.assertions(0)
+    const pcg = createPcg32({}, 42, 54)
+    const seen = new Set<unknown>()
+    const walk = (value: unknown): void => {
+      if (value === null || typeof value !== 'object') {
+        if (typeof value === 'function') throw new Error('state contains a function')
+        if (typeof value === 'bigint') throw new Error('state contains a bigint')
+        return
+      }
+      if (seen.has(value)) return
+      seen.add(value)
+      for (const v of Object.values(value as Record<string, unknown>)) walk(v)
+    }
+    walk(pcg)
+  })
+
+  it('survives serialization with non-default scheme and output function', () => {
+    expect.assertions(1)
+    const pcg = createPcg32({ streamScheme: StreamScheme.ONESEQ, outputFnType: OutputFnType.RXS_M_XS }, 42, 54)
+    const revived = JSON.parse(JSON.stringify(pcg)) as PCGState
+    const randomUint32 = randomInt(0, 2 ** 32 - 1)
+    expect(randomList(4, randomUint32, revived).map(([v]) => v)).toStrictEqual(
+      randomList(4, randomUint32, pcg).map(([v]) => v)
+    )
+  })
+
+  it('toBigInt and fromBigInt round-trip arbitrary 64-bit values', () => {
+    expect.assertions(4)
+    const values = [0n, 1n, 0xffffffffn, 0x100000000n, 0xffffffffffffffffn]
+    for (const v of values.slice(0, 4)) {
+      expect(toBigInt(fromBigInt(v))).toBe(v)
+    }
+  })
+
+  it('preserves state after multiple nextState calls across a round-trip', () => {
+    expect.assertions(1)
+    const pcg = createPcg32({}, 42, 54)
+    let live = pcg
+    let revived: PCGState = JSON.parse(JSON.stringify(pcg))
+    for (let i = 0; i < 100; i++) {
+      live = nextState(live)
+      revived = nextState(JSON.parse(JSON.stringify(revived)))
+    }
+    expect(revived).toStrictEqual(live)
+  })
+})

--- a/src/createPcg.ts
+++ b/src/createPcg.ts
@@ -1,7 +1,39 @@
 import { pcgDefaultOutputFnType, pcgDefaultStreamScheme } from './defaults'
-import { CreatePcg, CreatePcgOptions, LongLike, PCGConfig, PCGState, RandomFn, SchemeFn, StreamScheme } from './types'
+import {
+  CreatePcg,
+  CreatePcgOptions,
+  LongLike,
+  PCGConfig,
+  PCGState,
+  PCGVariant,
+  RandomFn,
+  SchemeFn,
+  StreamScheme,
+  Uint64,
+} from './types'
 
+const MASK_32 = 0xffffffffn
 const MASK_64 = 0xffffffffffffffffn
+
+export const toBigInt = ({ hi, lo }: Uint64): bigint => (BigInt(hi) << 32n) | BigInt(lo)
+
+export const fromBigInt = (value: bigint): Uint64 => ({
+  hi: Number((value >> 32n) & MASK_32),
+  lo: Number(value & MASK_32),
+})
+
+const variantConfigs: Partial<Record<PCGVariant, PCGConfig>> = {}
+
+const getConfig = (variant: PCGVariant): PCGConfig => {
+  const config = variantConfigs[variant]
+  if (config === undefined) throw new Error(`Unknown PCG variant: ${String(variant)}`)
+  return config
+}
+
+export const getOutput = (pcg: PCGState): number => {
+  const config = getConfig(pcg.variant)
+  return config.outputFns[pcg.outputFnType](toBigInt(pcg.state))
+}
 
 /* Multi-step advance functions (jump-ahead, jump-back)
  *
@@ -13,15 +45,17 @@ const MASK_64 = 0xffffffffffffffffn
  * goes "the long way round".
  */
 const stepStateImpl = (delta: number, pcg: PCGState): PCGState => {
-  let currMultiplier = pcg.algorithm.multiplier
+  const config = getConfig(pcg.variant)
+  let currMultiplier = config.multiplier
+  const streamIdBig = toBigInt(pcg.streamId)
   const incrementers: Record<StreamScheme, SchemeFn> = {
-    [StreamScheme.SETSEQ]: () => pcg.streamId,
-    [StreamScheme.ONESEQ]: () => pcg.algorithm.increment,
+    [StreamScheme.SETSEQ]: () => streamIdBig,
+    [StreamScheme.ONESEQ]: () => config.increment,
     // TODO: [StreamScheme.UNIQUE]: () => null,
     [StreamScheme.MCG]: () => 0n,
   }
 
-  let currIncrement = incrementers[pcg.algorithm.streamScheme]()
+  let currIncrement = incrementers[pcg.streamScheme]()
 
   let accMultiplier = 1n
   let accIncrement = 0n
@@ -36,9 +70,10 @@ const stepStateImpl = (delta: number, pcg: PCGState): PCGState => {
     currMultiplier = (currMultiplier * currMultiplier) & MASK_64
   }
 
+  const stateBig = toBigInt(pcg.state)
   return {
     ...pcg,
-    state: (pcg.state * accMultiplier + accIncrement) & MASK_64,
+    state: fromBigInt((stateBig * accMultiplier + accIncrement) & MASK_64),
   }
 }
 
@@ -52,32 +87,36 @@ export function stepState(delta: number, pcg?: PCGState): PCGState | ((pcg: PCGS
 // Fast path for delta=1, which is the common case driven by randomInt.
 // Equivalent to stepState(1) but avoids the jump-ahead bookkeeping loop.
 export const nextState = (pcg: PCGState): PCGState => {
-  const scheme = pcg.algorithm.streamScheme
+  const config = getConfig(pcg.variant)
+  const scheme = pcg.streamScheme
   const increment =
     scheme === StreamScheme.SETSEQ
-      ? pcg.streamId
+      ? toBigInt(pcg.streamId)
       : scheme === StreamScheme.ONESEQ
-        ? pcg.algorithm.increment
+        ? config.increment
         : 0n
+  const stateBig = toBigInt(pcg.state)
   return {
     ...pcg,
-    state: (pcg.state * pcg.algorithm.multiplier + increment) & MASK_64,
+    state: fromBigInt((stateBig * config.multiplier + increment) & MASK_64),
   }
 }
 
 export const prevState = stepState(-1)
 
 const randomIntImpl = (min: number, max: number, pcg: PCGState): [number, PCGState] => {
+  const config = getConfig(pcg.variant)
+  const outputMaxRange = 2 ** config.numOutputBits
   const bound = max - min
-  if (bound < 0 || bound > pcg.algorithm.outputMaxRange) throw new RangeError()
+  if (bound < 0 || bound > outputMaxRange) throw new RangeError()
 
-  const threshold = (pcg.algorithm.outputMaxRange - bound) % bound
-  const getOutput = pcg.getOutput
+  const threshold = (outputMaxRange - bound) % bound
+  const outputFn = config.outputFns[pcg.outputFnType]
 
   let n: number
   let nextPcg = pcg
   do {
-    n = getOutput(nextPcg.state)
+    n = outputFn(toBigInt(nextPcg.state))
     nextPcg = nextState(nextPcg)
   } while (n < threshold)
 
@@ -133,24 +172,21 @@ export const randomList: RandomListFn = ((length: number, rng?: RandomFn<unknown
   return randomListImpl(length, rng, initPcg)
 }) as RandomListFn
 
-export default ({ numOutputBits, multiplier, increment, outputFns }: PCGConfig): CreatePcg =>
-  (
+export default (variant: PCGVariant, config: PCGConfig): CreatePcg => {
+  variantConfigs[variant] = config
+  return (
     { streamScheme = pcgDefaultStreamScheme, outputFnType = pcgDefaultOutputFnType }: CreatePcgOptions,
     initState: LongLike,
     initStreamId: LongLike
   ): PCGState => {
     const streamId = (((BigInt(initStreamId) & MASK_64) << 1n) | 1n) & MASK_64
-
-    return nextState({
-      state: (streamId + BigInt(initState)) & MASK_64,
-      streamId,
-      algorithm: {
-        streamScheme,
-        outputFnType,
-        outputMaxRange: 2 ** numOutputBits,
-        multiplier,
-        increment,
-      },
-      getOutput: outputFns[outputFnType],
-    })
+    const initial: PCGState = {
+      state: fromBigInt((streamId + BigInt(initState)) & MASK_64),
+      streamId: fromBigInt(streamId),
+      variant,
+      outputFnType,
+      streamScheme,
+    }
+    return nextState(initial)
   }
+}

--- a/src/createPcg.ts
+++ b/src/createPcg.ts
@@ -30,10 +30,8 @@ const getConfig = (variant: PCGVariant): PCGConfig => {
   return config
 }
 
-export const getOutput = (pcg: PCGState): number => {
-  const config = getConfig(pcg.variant)
-  return config.outputFns[pcg.outputFnType](toBigInt(pcg.state))
-}
+export const getOutput = (pcg: PCGState): number =>
+  getConfig(pcg.variant).outputFns[pcg.outputFnType](toBigInt(pcg.state))
 
 /* Multi-step advance functions (jump-ahead, jump-back)
  *
@@ -47,9 +45,8 @@ export const getOutput = (pcg: PCGState): number => {
 const stepStateImpl = (delta: number, pcg: PCGState): PCGState => {
   const config = getConfig(pcg.variant)
   let currMultiplier = config.multiplier
-  const streamIdBig = toBigInt(pcg.streamId)
   const incrementers: Record<StreamScheme, SchemeFn> = {
-    [StreamScheme.SETSEQ]: () => streamIdBig,
+    [StreamScheme.SETSEQ]: () => toBigInt(pcg.streamId),
     [StreamScheme.ONESEQ]: () => config.increment,
     // TODO: [StreamScheme.UNIQUE]: () => null,
     [StreamScheme.MCG]: () => 0n,
@@ -70,10 +67,9 @@ const stepStateImpl = (delta: number, pcg: PCGState): PCGState => {
     currMultiplier = (currMultiplier * currMultiplier) & MASK_64
   }
 
-  const stateBig = toBigInt(pcg.state)
   return {
     ...pcg,
-    state: fromBigInt((stateBig * accMultiplier + accIncrement) & MASK_64),
+    state: fromBigInt((toBigInt(pcg.state) * accMultiplier + accIncrement) & MASK_64),
   }
 }
 
@@ -88,17 +84,15 @@ export function stepState(delta: number, pcg?: PCGState): PCGState | ((pcg: PCGS
 // Equivalent to stepState(1) but avoids the jump-ahead bookkeeping loop.
 export const nextState = (pcg: PCGState): PCGState => {
   const config = getConfig(pcg.variant)
-  const scheme = pcg.streamScheme
   const increment =
-    scheme === StreamScheme.SETSEQ
+    pcg.streamScheme === StreamScheme.SETSEQ
       ? toBigInt(pcg.streamId)
-      : scheme === StreamScheme.ONESEQ
+      : pcg.streamScheme === StreamScheme.ONESEQ
         ? config.increment
         : 0n
-  const stateBig = toBigInt(pcg.state)
   return {
     ...pcg,
-    state: fromBigInt((stateBig * config.multiplier + increment) & MASK_64),
+    state: fromBigInt((toBigInt(pcg.state) * config.multiplier + increment) & MASK_64),
   }
 }
 
@@ -180,13 +174,12 @@ export default (variant: PCGVariant, config: PCGConfig): CreatePcg => {
     initStreamId: LongLike
   ): PCGState => {
     const streamId = (((BigInt(initStreamId) & MASK_64) << 1n) | 1n) & MASK_64
-    const initial: PCGState = {
+    return nextState({
       state: fromBigInt((streamId + BigInt(initState)) & MASK_64),
       streamId: fromBigInt(streamId),
       variant,
       outputFnType,
       streamScheme,
-    }
-    return nextState(initial)
+    })
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,25 @@ import { pcgDefaultIncrement64, pcgDefaultMultiplier64 } from './defaults'
 import { OutputFnType } from './types'
 import createPcg from './createPcg'
 
-export { stepState, nextState, prevState, randomInt, randomList } from './createPcg'
+export { stepState, nextState, prevState, randomInt, randomList, getOutput, toBigInt, fromBigInt } from './createPcg'
 export { OutputFnType, StreamScheme } from './types'
-export type { CreatePcg, CreatePcgOptions, LongLike, OutputFn, PCGConfig, PCGState, RandomFn, SchemeFn } from './types'
+export type {
+  CreatePcg,
+  CreatePcgOptions,
+  LongLike,
+  OutputFn,
+  PCGConfig,
+  PCGState,
+  PCGVariant,
+  RandomFn,
+  SchemeFn,
+  Uint64,
+} from './types'
 
 const MASK_32 = 0xffffffffn
 const MASK_64 = 0xffffffffffffffffn
 
-export const createPcg32 = createPcg({
+export const createPcg32 = createPcg('pcg32', {
   numOutputBits: 32,
   multiplier: pcgDefaultMultiplier64,
   increment: pcgDefaultIncrement64,

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,15 @@ export type SchemeFn = () => bigint
 
 export type LongLike = bigint | number | string
 
+// JSON-serializable representation of an unsigned 64-bit integer split into
+// two unsigned 32-bit halves. `hi` is the upper 32 bits, `lo` is the lower.
+export type Uint64 = {
+  hi: number
+  lo: number
+}
+
+export type PCGVariant = 'pcg32'
+
 export type PCGConfig = {
   numOutputBits: number
   multiplier: bigint
@@ -29,16 +38,11 @@ export type PCGConfig = {
 }
 
 export type PCGState = {
-  state: bigint
-  streamId: bigint
-  algorithm: {
-    streamScheme: StreamScheme
-    outputFnType: OutputFnType
-    outputMaxRange: number
-    multiplier: bigint
-    increment: bigint
-  }
-  getOutput: OutputFn
+  state: Uint64
+  streamId: Uint64
+  variant: PCGVariant
+  outputFnType: OutputFnType
+  streamScheme: StreamScheme
 }
 
 export type RandomFn<T> = (pcg: PCGState) => [T, PCGState]


### PR DESCRIPTION
Closes #179.

## Summary

Reshapes `PCGState` so it survives `JSON.stringify` / `JSON.parse` unchanged. Previously the state held a `getOutput` function and four `bigint` fields — neither survives JSON. This is the blocker the issue describes for local-first apps that want to persist or sync RNG state across clients.

## Approach

- **64-bit values as `{ hi, lo }` pairs** of unsigned 32-bit numbers. JSON numbers safely hold integers up to 2^53 - 1, so each half fits with room to spare. A new `Uint64` type captures this shape.
- **Move constants out of state.** `multiplier`, `increment`, `outputMaxRange`, and the `outputFns` table are properties of the PCG variant, not the evolving RNG state. They now live in a module-level registry keyed by a `variant: 'pcg32'` tag stored on the state.
- **Replace the per-state `getOutput` closure** with a `getOutput(pcg)` helper that looks up the function from the variant config.
- **Expose `toBigInt` / `fromBigInt`** for callers that need to inspect or construct the underlying 64-bit values directly.

Internal math still uses bigints — conversion happens at the edges of each step, so the algorithm itself is unchanged and existing reproducibility tests pass without touching their expected outputs.

### New `PCGState` shape

```ts
type PCGState = {
  state: { hi: number; lo: number }
  streamId: { hi: number; lo: number }
  variant: 'pcg32'
  outputFnType: OutputFnType
  streamScheme: StreamScheme
}
```

Round-trips cleanly:

```ts
const pcg = createPcg32({}, 42, 54)
const revived = JSON.parse(JSON.stringify(pcg))
randomInt(0, 2 ** 32 - 1, revived)[0] === randomInt(0, 2 ** 32 - 1, pcg)[0] // true
```

## Breaking changes

- `PCGState.state` and `PCGState.streamId` are now `{ hi, lo }` objects instead of `bigint`.
- `PCGState.algorithm` is gone. `outputFnType` and `streamScheme` are top-level fields; `multiplier` / `increment` / `outputMaxRange` are looked up from the variant registry.
- `PCGState.getOutput` is gone. Use the new exported `getOutput(pcg)` helper.

Suggest cutting a 2.0 for this.

## Test plan

- [x] All existing tests pass (29/29) with their original expected outputs — proves the underlying algorithm is unchanged.
- [x] New `serialize.test.ts` covers: JSON round-trip equality, resumed generation after persisting mid-sequence, no functions or bigints anywhere in state, round-trip under non-default scheme + output function, `toBigInt`/`fromBigInt` round-tripping arbitrary 64-bit values, and a 100-step round-trip loop.
- [x] `npm run lint` clean (only pre-existing warnings).
- [x] `npm run build` produces working CJS + ESM + d.ts bundles.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VEAuozREjaZgj8cjBR55ZM)_