### PR TITLE
test: cover curried randomInt/randomList APIs to reach 100% coverage

### DIFF
--- a/src/__tests__/curried.test.ts
+++ b/src/__tests__/curried.test.ts
@@ -1,0 +1,63 @@
+import { createPcg32, nextState, randomInt, randomList } from '..'
+import { OutputFnType, StreamScheme } from '..'
+
+describe('curried APIs', () => {
+  const pcg = createPcg32({}, 42, 54)
+  const directRng = randomInt(0, 2 ** 32 - 1)
+  const expected = directRng(pcg)
+
+  it('randomInt(min)(max)(pcg) is equivalent to randomInt(min, max, pcg)', () => {
+    expect.assertions(2)
+    const partial = randomInt(0)
+    const ranger = partial(2 ** 32 - 1)
+    const [value, next] = ranger(pcg)
+    expect(value).toBe(expected[0])
+    expect(next).toStrictEqual(expected[1])
+  })
+
+  it('randomInt(min)(max, pcg) is equivalent to randomInt(min, max, pcg)', () => {
+    expect.assertions(2)
+    const partial = randomInt(0)
+    const [value, next] = partial(2 ** 32 - 1, pcg)
+    expect(value).toBe(expected[0])
+    expect(next).toStrictEqual(expected[1])
+  })
+
+  it('randomList(length)(rng)(pcg) is equivalent to randomList(length, rng, pcg)', () => {
+    expect.assertions(1)
+    const expectedList = randomList(3, directRng, pcg)
+    const list = randomList(3)<number>(directRng)(pcg)
+    expect(list).toStrictEqual(expectedList)
+  })
+
+  it('randomList(length)(rng, pcg) is equivalent to randomList(length, rng, pcg)', () => {
+    expect.assertions(1)
+    const expectedList = randomList(3, directRng, pcg)
+    const list = randomList(3)<number>(directRng, pcg)
+    expect(list).toStrictEqual(expectedList)
+  })
+
+  it('randomList(length, rng)(pcg) is equivalent to randomList(length, rng, pcg)', () => {
+    expect.assertions(1)
+    const expectedList = randomList(3, directRng, pcg)
+    const list = randomList(3, directRng)(pcg)
+    expect(list).toStrictEqual(expectedList)
+  })
+
+  it('randomList of zero length returns an empty array', () => {
+    expect.assertions(1)
+    expect(randomList(0, directRng, pcg)).toStrictEqual([])
+  })
+
+  it('exposes OutputFnType and StreamScheme from the package entry point', () => {
+    expect.assertions(2)
+    expect(OutputFnType.XSH_RR).toBeDefined()
+    expect(StreamScheme.SETSEQ).toBeDefined()
+  })
+
+  it('throws when given an unknown variant via state mutation', () => {
+    expect.assertions(1)
+    const bad = { ...pcg, variant: 'unknown' as never }
+    expect(() => nextState(bad)).toThrow(/Unknown PCG variant/)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds tests covering the fully-curried call paths for `randomInt` and `randomList` (e.g. `randomInt(min)(max)(pcg)`, `randomList(length)(rng, pcg)`, `randomList(length, rng)(pcg)`).
- Adds tests for the zero-length `randomList` short-circuit, the unknown-variant error in `nextState`, and re-export access to `OutputFnType`/`StreamScheme` from the package entry point.
- Brings coverage from 93.05% / 75% / 83.33% / 96.46% to **100%** across statements, branches, functions, and lines.

## Test plan
- [x] `npm test -- --coverage` reports 100% across all four metrics.
- [x] `npm run lint` shows no new warnings/errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvvs3ZmKZ3iEPaq6mD6tL1)_