### PR TITLE
chore: prep v2.0.0 release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,33 @@ jobs:
       - run: npm test
       - run: npm run lint
 
+  compat:
+    runs-on: ubuntu-latest
+    needs: tests
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 16.x
+          - 18.x
+          - 20.x
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+      - run: npm install
+      - run: npm run build
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Smoke-test built dist (CJS)
+        run: |
+          node -e "const p = require('./dist/index.js'); const s = p.createPcg32({}, 42n, 54n); const [n, s2] = p.randomInt(0, 100)(s); if (typeof n !== 'number') process.exit(1); JSON.stringify(p.nextState(s2));"
+      - name: Smoke-test built dist (ESM)
+        run: |
+          node --input-type=module -e "import('./dist/index.mjs').then(p => { const s = p.createPcg32({}, 42n, 54n); const [n, s2] = p.randomInt(0, 100)(s); if (typeof n !== 'number') process.exit(1); JSON.stringify(p.nextState(s2)); })"
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 2.0.0
+
+### Breaking changes
+
+- **`PCGState` shape changed to be JSON-serializable** (#179, #330). The 64-bit
+  `state` and `streamId` fields are now `{ hi: number, lo: number }` objects
+  (`Uint64`) instead of native `bigint`s. Consumers that persisted v1.x state
+  via `JSON.stringify` / structured clone must migrate; raw bigint state from
+  v1.x will not round-trip.
+- **Public typings tightened** (#240, #318, #319, #320). `createPcg32`'s return
+  type is now a nameable `PCGState` rather than an inferred anonymous type.
+  Code that relied on the previous inferred shape may need to import
+  `PCGState` explicitly.
+- **Minimum Node.js version is now 16.** Declared via `engines.node`.
+
+### Performance
+
+- ~7× faster `randomInt` / `nextState` / `randomList` hot path (#328).
+- Scheme→increment dispatch moved into the PCG config (#331).
+
+### Fixes
+
+- `randomInt` now allows a bound equal to `outputMaxRange` (#329).
+
+### Build / tooling
+
+- Switched from `tsc` to `tsup` for dual ESM/CJS output (#317).
+- Upgraded to TypeScript 6, ESLint 9 (flat config), and the Node 24 tsconfig
+  base. CI matrix now covers Node 22 and 24.
+
+## 1.1.0
+
+See git history.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "pcg",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A functional typescript implementation of the PCG family random number generators",
   "sideEffects": false,
+  "engines": {
+    "node": ">=16"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump version to `2.0.0` and declare `engines.node >= 16`
- Add `CHANGELOG.md` documenting breaking changes (PCGState now JSON-serializable via `Uint64`, nameable `createPcg32` return type, Node 16 floor), perf wins, and tooling moves
- Extend CI with a `compat` job that builds on Node 24 then smoke-tests the dist (CJS + ESM) on Node 16/18/20, alongside the existing full lint+test matrix on Node 22/24

Node compatibility was verified locally by running CJS and ESM smoke imports of the built `dist/` against Node 16.20.2, 18.20.6, 20.15.1, 22.22.2, and 24.15.0. Node 14 wasn't tested (no arm64 macOS binaries, EOL since April 2023) so 16 is the declared floor.

## Test plan
- [ ] `tests` job passes on Node 22.x and 24.x
- [ ] `compat` job passes on Node 16.x, 18.x, 20.x
- [ ] `coverage` job still reports to Coveralls
- [ ] `npm pack --dry-run` ships only LICENSE, README, dist/, package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)