### PR TITLE
Add sfc32 as another variant

### DIFF
--- a/src/__tests__/sfc32.test.ts
+++ b/src/__tests__/sfc32.test.ts
@@ -1,0 +1,102 @@
+import { createSfc32, getOutput, nextState, randomInt, randomList, stepState } from '..'
+import { PCGState } from '../types'
+
+// Reference values produced by the canonical sfc32 (Chris Doty-Humphrey,
+// PractRand) seeded with a=b=c=seed, d=1, and 15 warmup rounds:
+//   function sfc32Step(s) {
+//     const t = (((s.a + s.b) >>> 0) + s.d) >>> 0
+//     return {
+//       a: (s.b ^ (s.b >>> 9)) >>> 0,
+//       b: (s.c + (s.c << 3)) >>> 0,
+//       c: ((((s.c << 21) | (s.c >>> 11)) >>> 0) + t) >>> 0,
+//       d: (s.d + 1) >>> 0,
+//       t,
+//     }
+//   }
+const CANONICAL_SEED_42 = [
+  1296217524, 1908088579, 2163594420, 882717154, 1079537450, 41221136, 53294074, 1415219387,
+]
+
+describe('sfc32', () => {
+  it('matches the canonical reference sequence for seed=42', () => {
+    expect.assertions(1)
+    let pcg = createSfc32(42)
+    const out: number[] = []
+    for (let i = 0; i < CANONICAL_SEED_42.length; i++) {
+      out.push(getOutput(pcg))
+      pcg = nextState(pcg)
+    }
+    expect(out).toStrictEqual(CANONICAL_SEED_42)
+  })
+
+  it('stamps state with variant: "sfc32"', () => {
+    expect.assertions(1)
+    expect(createSfc32(42).variant).toBe('sfc32')
+  })
+
+  it('drives randomInt without bias and stays in range', () => {
+    expect.assertions(2)
+    const rng = randomInt(0, 100)
+    let pcg = createSfc32(7)
+    let minSeen = 100
+    let maxSeen = 0
+    for (let i = 0; i < 1000; i++) {
+      const [v, next] = rng(pcg)
+      if (v < minSeen) minSeen = v
+      if (v > maxSeen) maxSeen = v
+      pcg = next
+    }
+    expect(minSeen).toBeGreaterThanOrEqual(0)
+    expect(maxSeen).toBeLessThan(100)
+  })
+
+  it('produces the same sequence through randomList as through nextState', () => {
+    expect.assertions(1)
+    const rng = randomInt(0, 2 ** 32 - 1)
+    const pcg = createSfc32(123)
+    const listed = randomList(5, rng, pcg).map(([v]) => v)
+
+    const stepped: number[] = []
+    let curr = pcg
+    for (let i = 0; i < 5; i++) {
+      const [v, next] = rng(curr)
+      stepped.push(v)
+      curr = next
+    }
+    expect(stepped).toStrictEqual(listed)
+  })
+
+  it('stepState(n) advances by n single steps', () => {
+    expect.assertions(2)
+    const s0 = createSfc32(99)
+    let walked = s0
+    for (let i = 0; i < 7; i++) walked = nextState(walked)
+    const jumped = stepState(7, s0)
+    expect(jumped.state).toStrictEqual(walked.state)
+    expect(jumped.streamId).toStrictEqual(walked.streamId)
+  })
+
+  it('throws on negative delta because sfc32 is not reversible', () => {
+    expect.assertions(1)
+    expect(() => stepState(-1, createSfc32(1))).toThrow(RangeError)
+  })
+
+  it('survives JSON serialization round-trips', () => {
+    expect.assertions(1)
+    const pcg = createSfc32(42)
+    const revived = JSON.parse(JSON.stringify(pcg)) as PCGState
+    const rng = randomInt(0, 2 ** 32 - 1)
+    const a = randomList(8, rng, pcg).map(([v]) => v)
+    const b = randomList(8, rng, revived).map(([v]) => v)
+    expect(b).toStrictEqual(a)
+  })
+
+  it('accepts bigint, number, and string seeds', () => {
+    expect.assertions(2)
+    const a = createSfc32(42)
+    const b = createSfc32(42n)
+    const c = createSfc32('42')
+    expect(b.state).toStrictEqual(a.state)
+    expect(c.state).toStrictEqual(a.state)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { createMulberry32, mulberry32Advance, mulberry32Output } from './mulberry32'
 import { createPcg32, pcg32Advance, pcg32Output } from './pcg32'
-import { PCGState, PCGVariant, RandomFn, Uint64 } from './types'
+import { createSfc32, sfc32Advance, sfc32Output } from './sfc32'
+import { PCGState, PCGVariant, RandomFn } from './types'
 
 const NUM_OUTPUT_BITS = 32
 
@@ -9,25 +10,26 @@ const NUM_OUTPUT_BITS = 32
 export const createPcg = createPcg32
 
 type VariantImpl = {
-  advance: (pcg: PCGState, delta: number) => Uint64
+  advance: (pcg: PCGState, delta: number) => PCGState
   output: (pcg: PCGState) => number
 }
 
 const VARIANTS: Record<PCGVariant, VariantImpl> = {
   pcg32: { advance: pcg32Advance, output: pcg32Output },
   mulberry32: { advance: mulberry32Advance, output: mulberry32Output },
+  sfc32: { advance: sfc32Advance, output: sfc32Output },
 }
 
-const advance = (pcg: PCGState, delta: number): Uint64 => VARIANTS[pcg.variant].advance(pcg, delta)
+const advance = (pcg: PCGState, delta: number): PCGState => VARIANTS[pcg.variant].advance(pcg, delta)
 
 const output = (pcg: PCGState): number => VARIANTS[pcg.variant].output(pcg)
 
 export const getOutput = output
 
 // Fast path for delta=1, the common case driven by randomInt.
-export const nextState = (pcg: PCGState): PCGState => ({ ...pcg, state: advance(pcg, 1) })
+export const nextState = (pcg: PCGState): PCGState => advance(pcg, 1)
 
-const stepStateImpl = (delta: number, pcg: PCGState): PCGState => ({ ...pcg, state: advance(pcg, delta) })
+const stepStateImpl = (delta: number, pcg: PCGState): PCGState => advance(pcg, delta)
 
 export function stepState(delta: number): (pcg: PCGState) => PCGState
 export function stepState(delta: number, pcg: PCGState): PCGState
@@ -104,7 +106,7 @@ export const randomList: RandomListFn = ((length: number, rng?: RandomFn<unknown
   return randomListImpl(length, rng, initPcg)
 }) as RandomListFn
 
-export { createMulberry32, createPcg32 }
+export { createMulberry32, createPcg32, createSfc32 }
 export { fromBigInt, toBigInt } from './uint64'
 export { OutputFnType, StreamScheme } from './types'
 export type {

--- a/src/mulberry32.ts
+++ b/src/mulberry32.ts
@@ -1,4 +1,4 @@
-import { OutputFnType, PCGState, StreamScheme, Uint64 } from './types'
+import { OutputFnType, PCGState, StreamScheme } from './types'
 
 // Tommy Ettinger's mulberry32: a 32-bit counter-based PRNG with a period of
 // 2^32. Compact and fast, but with much weaker statistical properties and a
@@ -6,9 +6,9 @@ import { OutputFnType, PCGState, StreamScheme, Uint64 } from './types'
 // matter more than stream quality.
 const MULBERRY_INCREMENT = 0x6d2b79f5
 
-export const mulberry32Advance = (pcg: PCGState, delta: number): Uint64 => ({
-  hi: 0,
-  lo: (pcg.state.lo + Math.imul(delta, MULBERRY_INCREMENT)) >>> 0,
+export const mulberry32Advance = (pcg: PCGState, delta: number): PCGState => ({
+  ...pcg,
+  state: { hi: 0, lo: (pcg.state.lo + Math.imul(delta, MULBERRY_INCREMENT)) >>> 0 },
 })
 
 export const mulberry32Output = (pcg: PCGState): number => {

--- a/src/pcg32.ts
+++ b/src/pcg32.ts
@@ -71,9 +71,9 @@ const resolveStreamScheme = (streamScheme: StreamScheme | keyof typeof StreamSch
  * Society (Nov. 1994). Even though delta is unsigned in principle, passing a signed number works
  * by going "the long way round" via two's complement.
  */
-export const pcg32Advance = (pcg: PCGState, delta: number): Uint64 => {
+export const pcg32Advance = (pcg: PCGState, delta: number): PCGState => {
   const increment = INCREMENTERS[pcg.streamScheme](pcg)
-  if (delta === 1) return add64(mul64(pcg.state, MULTIPLIER), increment)
+  if (delta === 1) return { ...pcg, state: add64(mul64(pcg.state, MULTIPLIER), increment) }
 
   let currMultiplier = MULTIPLIER
   let currIncrement = increment
@@ -97,7 +97,7 @@ export const pcg32Advance = (pcg: PCGState, delta: number): Uint64 => {
     remHi = remHi >>> 1
   }
 
-  return add64(mul64(pcg.state, accMultiplier), accIncrement)
+  return { ...pcg, state: add64(mul64(pcg.state, accMultiplier), accIncrement) }
 }
 
 export const pcg32Output = (pcg: PCGState): number => OUTPUT_FNS[pcg.outputFnType](pcg.state)
@@ -117,5 +117,5 @@ export const createPcg32 = (
     outputFnType,
     streamScheme: resolvedScheme,
   }
-  return { ...seeded, state: pcg32Advance(seeded, 1) }
+  return pcg32Advance(seeded, 1)
 }

--- a/src/sfc32.ts
+++ b/src/sfc32.ts
@@ -1,0 +1,57 @@
+import { OutputFnType, PCGState, StreamScheme } from './types'
+
+// Chris Doty-Humphrey's sfc32: a 128-bit-state chaotic PRNG built from add,
+// xor, shift, and rotate. Fast, passes PractRand, and well-suited to JS since
+// every operation fits in 32 bits. State is packed as a=state.hi, b=state.lo,
+// c=streamId.hi, counter=streamId.lo. Not reversible — negative deltas throw.
+const BARREL_SHIFT = 21
+const RSHIFT = 9
+const LSHIFT = 3
+const WARMUP_ROUNDS = 15
+
+type Sfc32Registers = { a: number; b: number; c: number; d: number }
+
+const step = ({ a, b, c, d }: Sfc32Registers): Sfc32Registers => {
+  const t = (((a + b) >>> 0) + d) >>> 0
+  return {
+    a: (b ^ (b >>> RSHIFT)) >>> 0,
+    b: (c + (c << LSHIFT)) >>> 0,
+    c: ((((c << BARREL_SHIFT) | (c >>> (32 - BARREL_SHIFT))) >>> 0) + t) >>> 0,
+    d: (d + 1) >>> 0,
+  }
+}
+
+const unpack = (pcg: PCGState): Sfc32Registers => ({
+  a: pcg.state.hi,
+  b: pcg.state.lo,
+  c: pcg.streamId.hi,
+  d: pcg.streamId.lo,
+})
+
+const pack = (pcg: PCGState, { a, b, c, d }: Sfc32Registers): PCGState => ({
+  ...pcg,
+  state: { hi: a, lo: b },
+  streamId: { hi: c, lo: d },
+})
+
+export const sfc32Advance = (pcg: PCGState, delta: number): PCGState => {
+  if (delta < 0) throw new RangeError('sfc32 is not reversible; negative delta is unsupported')
+  let regs = unpack(pcg)
+  for (let i = 0; i < delta; i++) regs = step(regs)
+  return pack(pcg, regs)
+}
+
+export const sfc32Output = (pcg: PCGState): number =>
+  (((pcg.state.hi + pcg.state.lo) >>> 0) + pcg.streamId.lo) >>> 0
+
+export const createSfc32 = (seed: bigint | number | string): PCGState => {
+  const seedLo = Number(BigInt(seed) & 0xffffffffn)
+  const seeded: PCGState = {
+    state: { hi: seedLo, lo: seedLo },
+    streamId: { hi: seedLo, lo: 1 },
+    variant: 'sfc32',
+    outputFnType: OutputFnType.XSH_RR,
+    streamScheme: StreamScheme.SETSEQ,
+  }
+  return sfc32Advance(seeded, WARMUP_ROUNDS)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,9 +34,10 @@ export type LongLike = bigint | number | string
 
 // Reserved for future PCG variants (e.g. pcg64). Stored on every PCGState so
 // serialized state from older versions remains forward-compatible when a new
-// variant is introduced. `mulberry32` is a small 32-bit counter-based generator
-// (not part of the PCG family) that reuses the same state shape.
-export type PCGVariant = 'pcg32' | 'mulberry32'
+// variant is introduced. `mulberry32` and `sfc32` are non-PCG generators that
+// reuse the same state shape: mulberry32 packs into `state.lo`; sfc32 spreads
+// its four 32-bit registers across `state` (a, b) and `streamId` (c, counter).
+export type PCGVariant = 'pcg32' | 'mulberry32' | 'sfc32'
 
 export type PCGState = {
   state: Uint64


### PR DESCRIPTION
## Summary

Adds [sfc32](https://pracrand.sourceforge.net/) (Chris Doty-Humphrey's "Small Fast Counter", 32-bit variant) as a third generator alongside `pcg32` and `mulberry32`.

- **Why sfc32?** Modern "fast and good enough" default: 128-bit state, passes PractRand, very fast in JS (no multiplies, all 32-bit ops). Sits between pcg32 (large state, jump-ahead, high quality) and mulberry32 (tiny state, weaker quality).
- **State packing.** Reuses the existing `PCGState` shape: `a = state.hi`, `b = state.lo`, `c = streamId.hi`, `counter = streamId.lo` — fully JSON-serializable.
- **Seeding.** PractRand-style: `a = b = c = seed`, `counter = 1`, 15 warmup rounds.
- **Not reversible.** sfc32 has no closed-form inverse, so `sfc32Advance` throws `RangeError` on negative delta. `prevState`/`stepState(-n)` on an sfc32 state will throw — documented in the throw message and covered by tests.

### Dispatch contract change (internal)

The variant dispatch in `index.ts` widened from `(pcg, delta) => Uint64` to `(pcg, delta) => PCGState`. sfc32 needs to evolve all four 32-bit registers, not just `.state`. The affected functions (`pcg32Advance`, `mulberry32Advance`) aren't part of the public API — only the variant factories and the generic `nextState`/`getOutput`/`stepState`/`randomInt`/`randomList` surface are exported.

## Test plan

- [x] 8 new tests in `src/__tests__/sfc32.test.ts` (canonical reference sequence for seed=42, variant tag, randomInt range, randomList parity, stepState multi-step, negative-delta throws, JSON round-trip, bigint/number/string seeds)
- [x] All 88 tests pass (was 80)
- [x] `pnpm lint` clean (only pre-existing warnings)
- [x] `pnpm build` clean (ESM + CJS + DTS)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8JAm6fhLKYvdvp75pVzyW)_