### PR TITLE
Migrate test suite from jest to node:test

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,6 @@
 const js = require('@eslint/js')
 const tseslint = require('typescript-eslint')
 const importPlugin = require('eslint-plugin-import')
-const jestPlugin = require('eslint-plugin-jest')
 
 module.exports = [
   js.configs.recommended,
@@ -40,13 +39,6 @@ module.exports = [
           caughtErrorsIgnorePattern: '_',
         },
       ],
-    },
-  },
-  {
-    files: ['src/**/__tests__/**/*.ts'],
-    plugins: { jest: jestPlugin },
-    rules: {
-      ...jestPlugin.configs.recommended.rules,
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint": "eslint src",
     "prepare": "husky install && npm run build",
     "test": "node --import tsx --test 'src/__tests__/*.test.ts'",
-    "test:coverage": "node --import tsx --test --experimental-test-coverage 'src/__tests__/*.test.ts'",
+    "test:coverage": "mkdir -p coverage && node --import tsx --test --experimental-test-coverage --test-coverage-exclude='src/__tests__/**' --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info 'src/__tests__/*.test.ts'",
     "test:watch": "node --import tsx --test --watch 'src/__tests__/*.test.ts'"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,38 +34,29 @@
     "build": "tsup",
     "lint": "eslint src",
     "prepare": "husky install && npm run build",
-    "test": "jest",
-    "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test": "node --import tsx --test 'src/__tests__/*.test.ts'",
+    "test:coverage": "node --import tsx --test --experimental-test-coverage 'src/__tests__/*.test.ts'",
+    "test:watch": "node --import tsx --test --watch 'src/__tests__/*.test.ts'"
   },
-  "dependencies": {},
   "devDependencies": {
     "@eslint/js": "9.39.4",
     "@philihp/prettier-config": "1.0.0",
     "@tsconfig/node24": "24.0.4",
-    "@types/jest": "30.0.0",
+    "@types/node": "^25.9.1",
     "eslint": "9.39.4",
     "eslint-import-resolver-typescript": "4.4.4",
     "eslint-plugin-import": "2.32.0",
-    "eslint-plugin-jest": "29.15.2",
     "husky": "9.1.7",
-    "jest": "30.4.2",
     "lint-staged": "17.0.5",
     "prettier": "3.8.3",
-    "ts-jest": "29.4.9",
     "tsup": "^8.5.1",
+    "tsx": "^4.22.3",
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.3"
   },
   "lint-staged": {
     "src/**/*.ts": [
       "eslint --fix"
-    ]
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "modulePathIgnorePatterns": [
-      "dist/"
     ]
   },
   "prettier": "@philihp/prettier-config"

--- a/src/__tests__/bitwise.test.ts
+++ b/src/__tests__/bitwise.test.ts
@@ -1,27 +1,23 @@
-import { ror, ror8, ror16, ror32 } from '../bitwise'
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { ror32 } from '../bitwise'
 
 describe('bitwise', () => {
   describe('ror32', () => {
-    it('works', () => {
-      expect.assertions(1)
-      expect(true).toBeTruthy()
+    test('works', () => {
+      assert.ok(true)
     })
-    it('shifts 54 by 42', () => {
-      expect.assertions(1)
-      const out = ror32(54, 42)
-      expect(out).toBe(43008)
+    test('shifts 54 by 42', () => {
+      assert.equal(ror32(54, 42), 43008)
     })
-    it('shifts -54 by 42', () => {
-      expect.assertions(1)
-      expect(ror32(-54, 42)).toBe(176160768)
+    test('shifts -54 by 42', () => {
+      assert.equal(ror32(-54, 42), 176160768)
     })
-    it('shifts 54 by -42', () => {
-      expect.assertions(1)
-      expect(ror32(54, -42)).toBe(4294925311)
+    test('shifts 54 by -42', () => {
+      assert.equal(ror32(54, -42), 4294925311)
     })
-    it('shifts -54 by -42', () => {
-      expect.assertions(1)
-      expect(ror32(-54, -42)).toBe(4123000831)
+    test('shifts -54 by -42', () => {
+      assert.equal(ror32(-54, -42), 4123000831)
     })
   })
 })

--- a/src/__tests__/createPcg32.test.ts
+++ b/src/__tests__/createPcg32.test.ts
@@ -1,151 +1,136 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createPcg32, getOutput, nextState, prevState, randomInt, randomList } from '..'
 import { OutputFnType } from '../types'
 
 describe('basic', () => {
-  it('pCG32_XSH_RR: Single integer', () => {
-    expect.assertions(2)
+  test('pCG32_XSH_RR: Single integer', () => {
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
     const pcg = createPcg32({}, 42, 54)
     // Check for generator immutability and result reproducibility
-    const [n, _state] = randomUint32(pcg)
-    expect(n).toBe(0xa15c02b7)
-    expect(randomUint32(pcg)[0]).toBe(0xa15c02b7)
+    const [n] = randomUint32(pcg)
+    assert.equal(n, 0xa15c02b7)
+    assert.equal(randomUint32(pcg)[0], 0xa15c02b7)
   })
 
-  it('pCG32_XSH_RS: Single integer', () => {
-    expect.assertions(2)
+  test('pCG32_XSH_RS: Single integer', () => {
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
     const pcg = createPcg32({ outputFnType: OutputFnType.XSH_RS }, 42, 54)
-    // Check for generator immutability and result reproducibility
-    const [n, _state] = randomUint32(pcg)
-    expect(n).toBe(1545299392)
-    expect(randomUint32(pcg)[0]).toBe(1545299392)
+    const [n] = randomUint32(pcg)
+    assert.equal(n, 1545299392)
+    assert.equal(randomUint32(pcg)[0], 1545299392)
   })
 
-  it('pCG32_XSL_RR: Single integer', () => {
-    expect.assertions(2)
+  test('pCG32_XSL_RR: Single integer', () => {
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
     const pcg = createPcg32({ outputFnType: OutputFnType.XSL_RR }, 42, 54)
-    // Check for generator immutability and result reproducibility
-    const [n, _state] = randomUint32(pcg)
-    expect(n).toBe(110043304)
-    expect(randomUint32(pcg)[0]).toBe(110043304)
+    const [n] = randomUint32(pcg)
+    assert.equal(n, 110043304)
+    assert.equal(randomUint32(pcg)[0], 110043304)
   })
 
-  it('pCG32_RXS_M_XS: Single integer', () => {
-    expect.assertions(2)
+  test('pCG32_RXS_M_XS: Single integer', () => {
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
     const pcg = createPcg32({ outputFnType: OutputFnType.RXS_M_XS }, 42, 54)
-    // Check for generator immutability and result reproducibility
-    const [n, _state] = randomUint32(pcg)
-    expect(n).toBe(3562606574)
-    expect(randomUint32(pcg)[0]).toBe(3562606574)
+    const [n] = randomUint32(pcg)
+    assert.equal(n, 3562606574)
+    assert.equal(randomUint32(pcg)[0], 3562606574)
   })
 
-  it('pCG32_XSH_RR: Multiple integers', () => {
-    expect.assertions(1)
+  test('pCG32_XSH_RR: Multiple integers', () => {
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
     const pcg = createPcg32({}, 42, 54)
-    expect(randomList(6, randomUint32, pcg).map(([value]) => value)).toStrictEqual([
-      0xa15c02b7, 0x7b47f409, 0xba1d3330, 0x83d2f293, 0xbfa4784b, 0xcbed606e,
-    ])
+    assert.deepEqual(
+      randomList(6, randomUint32, pcg).map(([value]) => value),
+      [0xa15c02b7, 0x7b47f409, 0xba1d3330, 0x83d2f293, 0xbfa4784b, 0xcbed606e]
+    )
   })
 
-  it('pCG32_XSH_RS: Multiple integers', () => {
-    expect.assertions(1)
+  test('pCG32_XSH_RS: Multiple integers', () => {
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
     const pcg = createPcg32({ outputFnType: OutputFnType.XSH_RS }, 42, 54)
-    expect(randomList(6, randomUint32, pcg).map(([value]) => value)).toStrictEqual([
-      1545299392, 2415717169, 3435843701, 3090997190, 1576856010, 3235194092,
-    ])
+    assert.deepEqual(
+      randomList(6, randomUint32, pcg).map(([value]) => value),
+      [1545299392, 2415717169, 3435843701, 3090997190, 1576856010, 3235194092]
+    )
   })
 
-  it('pCG32_XSL_RR: Multiple integers', () => {
-    expect.assertions(1)
+  test('pCG32_XSL_RR: Multiple integers', () => {
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
     const pcg = createPcg32({ outputFnType: OutputFnType.XSL_RR }, 42, 54)
-    expect(randomList(6, randomUint32, pcg).map(([value]) => value)).toStrictEqual([
-      110043304, 3982559790, 957466950, 3645676572, 223035418, 2465086851,
-    ])
+    assert.deepEqual(
+      randomList(6, randomUint32, pcg).map(([value]) => value),
+      [110043304, 3982559790, 957466950, 3645676572, 223035418, 2465086851]
+    )
   })
 
-  it('pCG32_RXS_M_XS: Multiple integers', () => {
-    expect.assertions(1)
+  test('pCG32_RXS_M_XS: Multiple integers', () => {
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
     const pcg = createPcg32({ outputFnType: OutputFnType.RXS_M_XS }, 42, 54)
-    expect(randomList(6, randomUint32, pcg).map(([value]) => value)).toStrictEqual([
-      3562606574, 3701842622, 2826130885, 1212371962, 849807893, 1843984456,
-    ])
+    assert.deepEqual(
+      randomList(6, randomUint32, pcg).map(([value]) => value),
+      [3562606574, 3701842622, 2826130885, 1212371962, 849807893, 1843984456]
+    )
   })
 
-  it('pCG32_XSH_RR: Jump-ahead, jump-back', () => {
-    expect.assertions(5)
+  test('pCG32_XSH_RR: Jump-ahead, jump-back', () => {
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
     const pcg = createPcg32({}, 42, 54)
 
-    expect(randomUint32(nextState(pcg))[0]).toBe(0x7b47f409)
-    expect(randomUint32(prevState(nextState(pcg)))[0]).toBe(0xa15c02b7)
+    assert.equal(randomUint32(nextState(pcg))[0], 0x7b47f409)
+    assert.equal(randomUint32(prevState(nextState(pcg)))[0], 0xa15c02b7)
 
-    expect(randomUint32(pcg)[1]).toStrictEqual(nextState(pcg))
+    assert.deepEqual(randomUint32(pcg)[1], nextState(pcg))
 
-    expect(prevState(nextState(pcg))).toStrictEqual(pcg)
-    expect(nextState(prevState(pcg))).toStrictEqual(pcg)
+    assert.deepEqual(prevState(nextState(pcg)), pcg)
+    assert.deepEqual(nextState(prevState(pcg)), pcg)
   })
 
-  it('can generate a number', () => {
-    expect.assertions(2)
-    const advancedOptions = {}
-    const initState = 42
-    const initStreamId = 54
-    const pcg = createPcg32(advancedOptions, initState, initStreamId)
+  test('can generate a number', () => {
+    const pcg = createPcg32({}, 42, 54)
 
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
     const [value, nextPcg] = randomUint32(pcg)
 
-    expect(value).toBe(2707161783)
-    expect(nextPcg).toBeDefined()
+    assert.equal(value, 2707161783)
+    assert.notEqual(nextPcg, undefined)
   })
 
-  it('complains when range is wrong', () => {
-    expect.assertions(1)
+  test('complains when range is wrong', () => {
     const pcg = createPcg32({}, 42, 1)
-    expect(() => randomInt(0, -1, pcg)).toThrow(RangeError)
+    assert.throws(() => randomInt(0, -1, pcg), RangeError)
   })
 
-  it('supports the full 32-bit output range (bound === 2^32)', () => {
-    expect.assertions(2)
+  test('supports the full 32-bit output range (bound === 2^32)', () => {
     const pcg = createPcg32({}, 42, 54)
     const randomFullUint32 = randomInt(0, 2 ** 32)
     // With bound === outputMaxRange, threshold is 0 and the raw output is
     // returned unmodified, so this should match the first raw XSH_RR output.
-    expect(randomFullUint32(pcg)[0]).toBe(0xa15c02b7)
-    expect(() => randomInt(0, 2 ** 32 + 1, pcg)).toThrow(RangeError)
+    assert.equal(randomFullUint32(pcg)[0], 0xa15c02b7)
+    assert.throws(() => randomInt(0, 2 ** 32 + 1, pcg), RangeError)
   })
 
-  it('can generate a list, with corresponding states', () => {
-    expect.assertions(3)
-    const advancedOptions = {}
-    const initState = 42
-    const initStreamId = 54
-    const pcg = createPcg32(advancedOptions, initState, initStreamId)
+  test('can generate a list, with corresponding states', () => {
+    const pcg = createPcg32({}, 42, 54)
 
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
-    const listLength = 6
-    const out = randomList(listLength, randomUint32, pcg)
+    const out = randomList(6, randomUint32, pcg)
 
-    expect(out).toHaveLength(6)
-    expect(out.map((n) => n[0])).toStrictEqual([2707161783, 2068313097, 3122475824, 2211639955, 3215226955, 3421331566])
+    assert.equal(out.length, 6)
+    assert.deepEqual(
+      out.map((n) => n[0]),
+      [2707161783, 2068313097, 3122475824, 2211639955, 3215226955, 3421331566]
+    )
 
     // the next int after the 3rd state is the 4th int
-    expect(randomUint32(out[2][1])[0]).toBe(out[3][0])
+    assert.equal(randomUint32(out[2][1])[0], out[3][0])
   })
 
-  it('make sure there are no infinite loops', () => {
-    expect.assertions(65536)
+  test('make sure there are no infinite loops', () => {
     for (let x = 0; x < 256; x++) {
       for (let y = 0; y < 256; y++) {
         const pcg = createPcg32({}, x, y)
-        expect(getOutput(pcg)).not.toBe(0)
+        assert.notEqual(getOutput(pcg), 0)
       }
     }
   })

--- a/src/__tests__/curried.test.ts
+++ b/src/__tests__/curried.test.ts
@@ -1,3 +1,5 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createPcg32, randomInt, randomList } from '..'
 import { OutputFnType, StreamScheme } from '..'
 
@@ -6,53 +8,45 @@ describe('curried APIs', () => {
   const directRng = randomInt(0, 2 ** 32 - 1)
   const expected = directRng(pcg)
 
-  it('randomInt(min)(max)(pcg) is equivalent to randomInt(min, max, pcg)', () => {
-    expect.assertions(2)
+  test('randomInt(min)(max)(pcg) is equivalent to randomInt(min, max, pcg)', () => {
     const partial = randomInt(0)
     const ranger = partial(2 ** 32 - 1)
     const [value, next] = ranger(pcg)
-    expect(value).toBe(expected[0])
-    expect(next).toStrictEqual(expected[1])
+    assert.equal(value, expected[0])
+    assert.deepEqual(next, expected[1])
   })
 
-  it('randomInt(min)(max, pcg) is equivalent to randomInt(min, max, pcg)', () => {
-    expect.assertions(2)
+  test('randomInt(min)(max, pcg) is equivalent to randomInt(min, max, pcg)', () => {
     const partial = randomInt(0)
     const [value, next] = partial(2 ** 32 - 1, pcg)
-    expect(value).toBe(expected[0])
-    expect(next).toStrictEqual(expected[1])
+    assert.equal(value, expected[0])
+    assert.deepEqual(next, expected[1])
   })
 
-  it('randomList(length)(rng)(pcg) is equivalent to randomList(length, rng, pcg)', () => {
-    expect.assertions(1)
+  test('randomList(length)(rng)(pcg) is equivalent to randomList(length, rng, pcg)', () => {
     const expectedList = randomList(3, directRng, pcg)
     const list = randomList(3)<number>(directRng)(pcg)
-    expect(list).toStrictEqual(expectedList)
+    assert.deepEqual(list, expectedList)
   })
 
-  it('randomList(length)(rng, pcg) is equivalent to randomList(length, rng, pcg)', () => {
-    expect.assertions(1)
+  test('randomList(length)(rng, pcg) is equivalent to randomList(length, rng, pcg)', () => {
     const expectedList = randomList(3, directRng, pcg)
     const list = randomList(3)<number>(directRng, pcg)
-    expect(list).toStrictEqual(expectedList)
+    assert.deepEqual(list, expectedList)
   })
 
-  it('randomList(length, rng)(pcg) is equivalent to randomList(length, rng, pcg)', () => {
-    expect.assertions(1)
+  test('randomList(length, rng)(pcg) is equivalent to randomList(length, rng, pcg)', () => {
     const expectedList = randomList(3, directRng, pcg)
     const list = randomList(3, directRng)(pcg)
-    expect(list).toStrictEqual(expectedList)
+    assert.deepEqual(list, expectedList)
   })
 
-  it('randomList of zero length returns an empty array', () => {
-    expect.assertions(1)
-    expect(randomList(0, directRng, pcg)).toStrictEqual([])
+  test('randomList of zero length returns an empty array', () => {
+    assert.deepEqual(randomList(0, directRng, pcg), [])
   })
 
-  it('exposes OutputFnType and StreamScheme from the package entry point', () => {
-    expect.assertions(2)
-    expect(OutputFnType.XSH_RR).toBeDefined()
-    expect(StreamScheme.SETSEQ).toBeDefined()
+  test('exposes OutputFnType and StreamScheme from the package entry point', () => {
+    assert.notEqual(OutputFnType.XSH_RR, undefined)
+    assert.notEqual(StreamScheme.SETSEQ, undefined)
   })
-
 })

--- a/src/__tests__/deprecated.test.ts
+++ b/src/__tests__/deprecated.test.ts
@@ -2,43 +2,41 @@
 // aliases until 3.0.0. If any of these stop working, downstream consumers who
 // upgraded to 2.0.0 will see a hard break.
 
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { fromBigInt, toBigInt } from '..'
 import type { LongLike, StreamSchemeName } from '..'
 import { StreamScheme } from '..'
 
 describe('deprecated 2.0.0 exports', () => {
-  it('toBigInt round-trips with fromBigInt', () => {
-    expect.assertions(5)
+  test('toBigInt round-trips with fromBigInt', () => {
     const values = [0n, 1n, 0xffffffffn, 0x100000000n, 0xdeadbeefcafebaben]
     for (const v of values) {
-      expect(toBigInt(fromBigInt(v))).toBe(v)
+      assert.equal(toBigInt(fromBigInt(v)), v)
     }
   })
 
-  it('fromBigInt produces JSON-clean { hi, lo } objects', () => {
-    expect.assertions(2)
+  test('fromBigInt produces JSON-clean { hi, lo } objects', () => {
     const u = fromBigInt(0x123456789abcdef0n)
-    expect(u).toEqual({ hi: 0x12345678, lo: 0x9abcdef0 })
-    expect(JSON.parse(JSON.stringify(u))).toEqual(u)
+    assert.deepEqual(u, { hi: 0x12345678, lo: 0x9abcdef0 })
+    assert.deepEqual(JSON.parse(JSON.stringify(u)), u)
   })
 
-  it('LongLike still accepts bigint, number, and string', () => {
-    expect.assertions(3)
+  test('LongLike still accepts bigint, number, and string', () => {
     const a: LongLike = 42
     const b: LongLike = 42n
     const c: LongLike = '42'
-    expect(typeof a).toBe('number')
-    expect(typeof b).toBe('bigint')
-    expect(typeof c).toBe('string')
+    assert.equal(typeof a, 'number')
+    assert.equal(typeof b, 'bigint')
+    assert.equal(typeof c, 'string')
   })
 
-  it('StreamSchemeName matches the StreamScheme keys', () => {
-    expect.assertions(3)
+  test('StreamSchemeName matches the StreamScheme keys', () => {
     const setseq: StreamSchemeName = 'SETSEQ'
     const oneseq: StreamSchemeName = 'ONESEQ'
     const mcg: StreamSchemeName = 'MCG'
-    expect(StreamScheme[setseq]).toBe(StreamScheme.SETSEQ)
-    expect(StreamScheme[oneseq]).toBe(StreamScheme.ONESEQ)
-    expect(StreamScheme[mcg]).toBe(StreamScheme.MCG)
+    assert.equal(StreamScheme[setseq], StreamScheme.SETSEQ)
+    assert.equal(StreamScheme[oneseq], StreamScheme.ONESEQ)
+    assert.equal(StreamScheme[mcg], StreamScheme.MCG)
   })
 })

--- a/src/__tests__/fastPath.test.ts
+++ b/src/__tests__/fastPath.test.ts
@@ -1,3 +1,5 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createPcg32, getOutput, nextState, prevState, randomInt, stepState } from '..'
 import { OutputFnType, PCGState, StreamScheme, Uint64 } from '../types'
 
@@ -17,8 +19,7 @@ const fromBig = (v: bigint): Uint64 => ({
 const referenceNext = (state: bigint, increment: bigint): bigint => (state * MULT + increment) & MASK_64
 
 describe('fast path correctness vs BigInt reference', () => {
-  it('nextState matches the BigInt LCG for SETSEQ across 1k iterations', () => {
-    expect.assertions(1000)
+  test('nextState matches the BigInt LCG for SETSEQ across 1k iterations', () => {
     const pcg = createPcg32({ streamScheme: StreamScheme.SETSEQ }, 42, 54)
     const streamInc = ((BigInt(54) & MASK_64) << 1n) | 1n
     let live: PCGState = pcg
@@ -26,77 +27,75 @@ describe('fast path correctness vs BigInt reference', () => {
     for (let i = 0; i < 1000; i++) {
       live = nextState(live)
       refState = referenceNext(refState, streamInc)
-      expect(live.state).toEqual(fromBig(refState))
+      assert.deepEqual(live.state, fromBig(refState))
     }
   })
 
-  it('nextState matches the BigInt LCG for ONESEQ across 1k iterations', () => {
-    expect.assertions(1000)
+  test('nextState matches the BigInt LCG for ONESEQ across 1k iterations', () => {
     const pcg = createPcg32({ streamScheme: StreamScheme.ONESEQ }, 42, 54)
     let live: PCGState = pcg
     let refState = toBig(pcg.state)
     for (let i = 0; i < 1000; i++) {
       live = nextState(live)
       refState = referenceNext(refState, INC)
-      expect(live.state).toEqual(fromBig(refState))
+      assert.deepEqual(live.state, fromBig(refState))
     }
   })
 
-  it('nextState matches the BigInt MCG (zero increment) across 1k iterations', () => {
-    expect.assertions(1000)
+  test('nextState matches the BigInt MCG (zero increment) across 1k iterations', () => {
     const pcg = createPcg32({ streamScheme: StreamScheme.MCG }, 42, 54)
     let live: PCGState = pcg
     let refState = toBig(pcg.state)
     for (let i = 0; i < 1000; i++) {
       live = nextState(live)
       refState = referenceNext(refState, 0n)
-      expect(live.state).toEqual(fromBig(refState))
+      assert.deepEqual(live.state, fromBig(refState))
     }
   })
 })
 
 describe('stepState fast-exponentiation', () => {
-  it('agrees with repeated nextState across a range of deltas', () => {
+  test('agrees with repeated nextState across a range of deltas', () => {
     const positiveDeltas = [1, 2, 3, 7, 16, 100, 10_000]
-    expect.assertions(positiveDeltas.length * 2 + 1)
     const pcg = createPcg32({}, 42, 54)
-    expect(stepState(0, pcg)).toEqual(pcg)
+    assert.deepEqual(stepState(0, pcg), pcg)
     for (const delta of positiveDeltas) {
       let walked = pcg
       for (let i = 0; i < delta; i++) walked = nextState(walked)
       const jumped = stepState(delta, pcg)
-      expect(jumped.state).toEqual(walked.state)
-      expect(stepState(-delta, jumped).state).toEqual(pcg.state)
+      assert.deepEqual(jumped.state, walked.state)
+      assert.deepEqual(stepState(-delta, jumped).state, pcg.state)
     }
   })
 
-  it('round-trips state through nextState/prevState chains', () => {
-    expect.assertions(50)
+  test('round-trips state through nextState/prevState chains', () => {
     let pcg = createPcg32({}, 7, 11)
     for (let i = 0; i < 50; i++) {
       const moved = prevState(nextState(pcg))
-      expect(moved.state).toEqual(pcg.state)
+      assert.deepEqual(moved.state, pcg.state)
       pcg = nextState(pcg)
     }
   })
 })
 
 describe('output functions over a large sample', () => {
-  it.each([
-    [OutputFnType.XSH_RR],
-    [OutputFnType.XSH_RS],
-    [OutputFnType.XSL_RR],
-    [OutputFnType.RXS_M_XS],
-  ])('produces 32-bit unsigned outputs for %i', (outputFnType) => {
-    const pcg = createPcg32({ outputFnType }, 42, 54)
-    const rng = randomInt(0, 2 ** 32 - 1)
-    let s = pcg
-    for (let i = 0; i < 1000; i++) {
-      const n = getOutput(s)
-      expect(Number.isInteger(n)).toBe(true)
-      expect(n).toBeGreaterThanOrEqual(0)
-      expect(n).toBeLessThanOrEqual(0xffffffff)
-      s = rng(s)[1]
-    }
-  })
+  for (const outputFnType of [
+    OutputFnType.XSH_RR,
+    OutputFnType.XSH_RS,
+    OutputFnType.XSL_RR,
+    OutputFnType.RXS_M_XS,
+  ] as const) {
+    test(`produces 32-bit unsigned outputs for ${outputFnType}`, () => {
+      const pcg = createPcg32({ outputFnType }, 42, 54)
+      const rng = randomInt(0, 2 ** 32 - 1)
+      let s = pcg
+      for (let i = 0; i < 1000; i++) {
+        const n = getOutput(s)
+        assert.ok(Number.isInteger(n))
+        assert.ok(n >= 0)
+        assert.ok(n <= 0xffffffff)
+        s = rng(s)[1]
+      }
+    })
+  }
 })

--- a/src/__tests__/mulberry32.test.ts
+++ b/src/__tests__/mulberry32.test.ts
@@ -1,3 +1,5 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createMulberry32, getOutput, nextState, prevState, randomInt, randomList, stepState } from '..'
 import { PCGState } from '../types'
 
@@ -16,24 +18,21 @@ const CANONICAL_SEED_42 = [
 ]
 
 describe('mulberry32', () => {
-  it('matches the canonical reference sequence for seed=42', () => {
-    expect.assertions(1)
+  test('matches the canonical reference sequence for seed=42', () => {
     let pcg = createMulberry32(42)
     const out: number[] = []
     for (let i = 0; i < CANONICAL_SEED_42.length; i++) {
       out.push(getOutput(pcg))
       pcg = nextState(pcg)
     }
-    expect(out).toStrictEqual(CANONICAL_SEED_42)
+    assert.deepEqual(out, CANONICAL_SEED_42)
   })
 
-  it('stamps state with variant: "mulberry32"', () => {
-    expect.assertions(1)
-    expect(createMulberry32(42).variant).toBe('mulberry32')
+  test('stamps state with variant: "mulberry32"', () => {
+    assert.equal(createMulberry32(42).variant, 'mulberry32')
   })
 
-  it('drives randomInt without bias and stays in range', () => {
-    expect.assertions(2)
+  test('drives randomInt without bias and stays in range', () => {
     const rng = randomInt(0, 100)
     let pcg = createMulberry32(7)
     let minSeen = 100
@@ -44,12 +43,11 @@ describe('mulberry32', () => {
       if (v > maxSeen) maxSeen = v
       pcg = next
     }
-    expect(minSeen).toBeGreaterThanOrEqual(0)
-    expect(maxSeen).toBeLessThan(100)
+    assert.ok(minSeen >= 0)
+    assert.ok(maxSeen < 100)
   })
 
-  it('produces the same sequence through randomList as through nextState', () => {
-    expect.assertions(1)
+  test('produces the same sequence through randomList as through nextState', () => {
     const rng = randomInt(0, 2 ** 32 - 1)
     const pcg = createMulberry32(123)
     const listed = randomList(5, rng, pcg).map(([v]) => v)
@@ -61,40 +59,36 @@ describe('mulberry32', () => {
       stepped.push(v)
       curr = next
     }
-    expect(stepped).toStrictEqual(listed)
+    assert.deepEqual(stepped, listed)
   })
 
-  it('stepState(n) advances by n single steps', () => {
-    expect.assertions(1)
+  test('stepState(n) advances by n single steps', () => {
     const s0 = createMulberry32(99)
     let walked = s0
     for (let i = 0; i < 7; i++) walked = nextState(walked)
     const jumped = stepState(7, s0)
-    expect(jumped.state).toStrictEqual(walked.state)
+    assert.deepEqual(jumped.state, walked.state)
   })
 
-  it('prevState undoes nextState', () => {
-    expect.assertions(1)
+  test('prevState undoes nextState', () => {
     const s0 = createMulberry32(2026)
-    expect(prevState(nextState(s0)).state).toStrictEqual(s0.state)
+    assert.deepEqual(prevState(nextState(s0)).state, s0.state)
   })
 
-  it('survives JSON serialization round-trips', () => {
-    expect.assertions(1)
+  test('survives JSON serialization round-trips', () => {
     const pcg = createMulberry32(42)
     const revived = JSON.parse(JSON.stringify(pcg)) as PCGState
     const rng = randomInt(0, 2 ** 32 - 1)
     const a = randomList(8, rng, pcg).map(([v]) => v)
     const b = randomList(8, rng, revived).map(([v]) => v)
-    expect(b).toStrictEqual(a)
+    assert.deepEqual(b, a)
   })
 
-  it('accepts bigint, number, and string seeds', () => {
-    expect.assertions(2)
+  test('accepts bigint, number, and string seeds', () => {
     const a = createMulberry32(42)
     const b = createMulberry32(42n)
     const c = createMulberry32('42')
-    expect(b.state).toStrictEqual(a.state)
-    expect(c.state).toStrictEqual(a.state)
+    assert.deepEqual(b.state, a.state)
+    assert.deepEqual(c.state, a.state)
   })
 })

--- a/src/__tests__/scheme.mcg.test.ts
+++ b/src/__tests__/scheme.mcg.test.ts
@@ -1,24 +1,22 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createPcg32, randomInt, randomList } from '..'
 import { StreamScheme } from '../types'
 
 describe('mcg', () => {
-  it('generates a list', () => {
-    expect.assertions(3)
-    const advancedOptions = {
-      streamScheme: StreamScheme.MCG,
-    }
-    const initState = 42
-    const initStreamId = 54
-    const pcg = createPcg32(advancedOptions, initState, initStreamId)
+  test('generates a list', () => {
+    const pcg = createPcg32({ streamScheme: StreamScheme.MCG }, 42, 54)
 
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
-    const listLength = 6
-    const out = randomList(listLength, randomUint32, pcg)
+    const out = randomList(6, randomUint32, pcg)
 
-    expect(out).toHaveLength(6)
-    expect(out.map((n) => n[0])).toStrictEqual([2707161783, 481379097, 3013076618, 44264614, 123970576, 1499079222])
+    assert.equal(out.length, 6)
+    assert.deepEqual(
+      out.map((n) => n[0]),
+      [2707161783, 481379097, 3013076618, 44264614, 123970576, 1499079222]
+    )
 
     // the next int after the 3rd state is the 4th int
-    expect(randomUint32(out[2][1])[0]).toBe(out[3][0])
+    assert.equal(randomUint32(out[2][1])[0], out[3][0])
   })
 })

--- a/src/__tests__/scheme.oneseq.test.ts
+++ b/src/__tests__/scheme.oneseq.test.ts
@@ -1,24 +1,22 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createPcg32, randomInt, randomList } from '..'
 import { StreamScheme } from '../types'
 
 describe('oneseq', () => {
-  it('generates a list', () => {
-    expect.assertions(3)
-    const advancedOptions = {
-      streamScheme: StreamScheme.ONESEQ,
-    }
-    const initState = 42
-    const initStreamId = 54
-    const pcg = createPcg32(advancedOptions, initState, initStreamId)
+  test('generates a list', () => {
+    const pcg = createPcg32({ streamScheme: StreamScheme.ONESEQ }, 42, 54)
 
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
-    const listLength = 6
-    const out = randomList(listLength, randomUint32, pcg)
+    const out = randomList(6, randomUint32, pcg)
 
-    expect(out).toHaveLength(6)
-    expect(out.map((n) => n[0])).toStrictEqual([73173280, 3745155691, 2856497084, 4276626055, 3324726470, 3500761220])
+    assert.equal(out.length, 6)
+    assert.deepEqual(
+      out.map((n) => n[0]),
+      [73173280, 3745155691, 2856497084, 4276626055, 3324726470, 3500761220]
+    )
 
     // the next int after the 3rd state is the 4th int
-    expect(randomUint32(out[2][1])[0]).toBe(out[3][0])
+    assert.equal(randomUint32(out[2][1])[0], out[3][0])
   })
 })

--- a/src/__tests__/scheme.setseq.test.ts
+++ b/src/__tests__/scheme.setseq.test.ts
@@ -1,24 +1,22 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createPcg32, randomInt, randomList } from '..'
 import { StreamScheme } from '../types'
 
 describe('setseq', () => {
-  it('generates a list', () => {
-    expect.assertions(3)
-    const advancedOptions = {
-      streamScheme: StreamScheme.SETSEQ,
-    }
-    const initState = 42
-    const initStreamId = 54
-    const pcg = createPcg32(advancedOptions, initState, initStreamId)
+  test('generates a list', () => {
+    const pcg = createPcg32({ streamScheme: StreamScheme.SETSEQ }, 42, 54)
 
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
-    const listLength = 6
-    const out = randomList(listLength, randomUint32, pcg)
+    const out = randomList(6, randomUint32, pcg)
 
-    expect(out).toHaveLength(6)
-    expect(out.map((n) => n[0])).toStrictEqual([2707161783, 2068313097, 3122475824, 2211639955, 3215226955, 3421331566])
+    assert.equal(out.length, 6)
+    assert.deepEqual(
+      out.map((n) => n[0]),
+      [2707161783, 2068313097, 3122475824, 2211639955, 3215226955, 3421331566]
+    )
 
     // the next int after the 3rd state is the 4th int
-    expect(randomUint32(out[2][1])[0]).toBe(out[3][0])
+    assert.equal(randomUint32(out[2][1])[0], out[3][0])
   })
 })

--- a/src/__tests__/scheme.string-options.test.ts
+++ b/src/__tests__/scheme.string-options.test.ts
@@ -1,18 +1,24 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createPcg32 } from '..'
 import { StreamScheme } from '../types'
 
 describe('streamScheme accepts a string name', () => {
-  it.each(['SETSEQ', 'ONESEQ', 'MCG'] as const)('matches the enum for %s', (name) => {
-    const fromString = createPcg32({ streamScheme: name }, 42, 54)
-    const fromEnum = createPcg32({ streamScheme: StreamScheme[name] }, 42, 54)
-    expect(fromString).toStrictEqual(fromEnum)
-    expect(fromString.streamScheme).toBe(StreamScheme[name])
-  })
+  for (const name of ['SETSEQ', 'ONESEQ', 'MCG'] as const) {
+    test(`matches the enum for ${name}`, () => {
+      const fromString = createPcg32({ streamScheme: name }, 42, 54)
+      const fromEnum = createPcg32({ streamScheme: StreamScheme[name] }, 42, 54)
+      assert.deepEqual(fromString, fromEnum)
+      assert.equal(fromString.streamScheme, StreamScheme[name])
+    })
+  }
 
-  it('throws on an unknown scheme name', () => {
-    expect(() =>
-      // @ts-expect-error - intentionally invalid name
-      createPcg32({ streamScheme: 'NOPE' }, 42, 54)
-    ).toThrow(/Unknown stream scheme/)
+  test('throws on an unknown scheme name', () => {
+    assert.throws(
+      () =>
+        // @ts-expect-error - intentionally invalid name
+        createPcg32({ streamScheme: 'NOPE' }, 42, 54),
+      /Unknown stream scheme/
+    )
   })
 })

--- a/src/__tests__/serialize.test.ts
+++ b/src/__tests__/serialize.test.ts
@@ -1,20 +1,20 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createPcg32, nextState, randomInt, randomList } from '..'
 import { OutputFnType, PCGState, StreamScheme } from '../types'
 
 describe('serialize', () => {
-  it('round-trips the state through JSON.stringify/parse', () => {
-    expect.assertions(2)
+  test('round-trips the state through JSON.stringify/parse', () => {
     const pcg = createPcg32({}, 42, 54)
     const json = JSON.stringify(pcg)
     const revived = JSON.parse(json) as PCGState
-    expect(revived).toStrictEqual(pcg)
+    assert.deepEqual(revived, pcg)
 
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
-    expect(randomUint32(revived)[0]).toBe(randomUint32(pcg)[0])
+    assert.equal(randomUint32(revived)[0], randomUint32(pcg)[0])
   })
 
-  it('continues a generation sequence after a serialization round-trip', () => {
-    expect.assertions(1)
+  test('continues a generation sequence after a serialization round-trip', () => {
     const pcg = createPcg32({}, 42, 54)
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
 
@@ -25,11 +25,10 @@ describe('serialize', () => {
     const persisted = JSON.parse(JSON.stringify(firstThree[2][1])) as PCGState
     const resumed = randomList(3, randomUint32, persisted).map(([v]) => v)
 
-    expect([...firstThree.map(([v]) => v), ...resumed]).toStrictEqual(reference)
+    assert.deepEqual([...firstThree.map(([v]) => v), ...resumed], reference)
   })
 
-  it('state contains no functions and no bigints', () => {
-    expect.assertions(0)
+  test('state contains no functions and no bigints', () => {
     const pcg = createPcg32({}, 42, 54)
     const seen = new Set<unknown>()
     const walk = (value: unknown): void => {
@@ -42,21 +41,20 @@ describe('serialize', () => {
       seen.add(value)
       for (const v of Object.values(value as Record<string, unknown>)) walk(v)
     }
-    walk(pcg)
+    assert.doesNotThrow(() => walk(pcg))
   })
 
-  it('survives serialization with non-default scheme and output function', () => {
-    expect.assertions(1)
+  test('survives serialization with non-default scheme and output function', () => {
     const pcg = createPcg32({ streamScheme: StreamScheme.ONESEQ, outputFnType: OutputFnType.RXS_M_XS }, 42, 54)
     const revived = JSON.parse(JSON.stringify(pcg)) as PCGState
     const randomUint32 = randomInt(0, 2 ** 32 - 1)
-    expect(randomList(4, randomUint32, revived).map(([v]) => v)).toStrictEqual(
+    assert.deepEqual(
+      randomList(4, randomUint32, revived).map(([v]) => v),
       randomList(4, randomUint32, pcg).map(([v]) => v)
     )
   })
 
-  it('preserves state after multiple nextState calls across a round-trip', () => {
-    expect.assertions(1)
+  test('preserves state after multiple nextState calls across a round-trip', () => {
     const pcg = createPcg32({}, 42, 54)
     let live = pcg
     let revived: PCGState = JSON.parse(JSON.stringify(pcg))
@@ -64,6 +62,6 @@ describe('serialize', () => {
       live = nextState(live)
       revived = nextState(JSON.parse(JSON.stringify(revived)))
     }
-    expect(revived).toStrictEqual(live)
+    assert.deepEqual(revived, live)
   })
 })

--- a/src/__tests__/sfc32.test.ts
+++ b/src/__tests__/sfc32.test.ts
@@ -1,3 +1,5 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createSfc32, getOutput, nextState, randomInt, randomList, stepState } from '..'
 import { PCGState } from '../types'
 
@@ -18,24 +20,21 @@ const CANONICAL_SEED_42 = [
 ]
 
 describe('sfc32', () => {
-  it('matches the canonical reference sequence for seed=42', () => {
-    expect.assertions(1)
+  test('matches the canonical reference sequence for seed=42', () => {
     let pcg = createSfc32(42)
     const out: number[] = []
     for (let i = 0; i < CANONICAL_SEED_42.length; i++) {
       out.push(getOutput(pcg))
       pcg = nextState(pcg)
     }
-    expect(out).toStrictEqual(CANONICAL_SEED_42)
+    assert.deepEqual(out, CANONICAL_SEED_42)
   })
 
-  it('stamps state with variant: "sfc32"', () => {
-    expect.assertions(1)
-    expect(createSfc32(42).variant).toBe('sfc32')
+  test('stamps state with variant: "sfc32"', () => {
+    assert.equal(createSfc32(42).variant, 'sfc32')
   })
 
-  it('drives randomInt without bias and stays in range', () => {
-    expect.assertions(2)
+  test('drives randomInt without bias and stays in range', () => {
     const rng = randomInt(0, 100)
     let pcg = createSfc32(7)
     let minSeen = 100
@@ -46,12 +45,11 @@ describe('sfc32', () => {
       if (v > maxSeen) maxSeen = v
       pcg = next
     }
-    expect(minSeen).toBeGreaterThanOrEqual(0)
-    expect(maxSeen).toBeLessThan(100)
+    assert.ok(minSeen >= 0)
+    assert.ok(maxSeen < 100)
   })
 
-  it('produces the same sequence through randomList as through nextState', () => {
-    expect.assertions(1)
+  test('produces the same sequence through randomList as through nextState', () => {
     const rng = randomInt(0, 2 ** 32 - 1)
     const pcg = createSfc32(123)
     const listed = randomList(5, rng, pcg).map(([v]) => v)
@@ -63,40 +61,36 @@ describe('sfc32', () => {
       stepped.push(v)
       curr = next
     }
-    expect(stepped).toStrictEqual(listed)
+    assert.deepEqual(stepped, listed)
   })
 
-  it('stepState(n) advances by n single steps', () => {
-    expect.assertions(2)
+  test('stepState(n) advances by n single steps', () => {
     const s0 = createSfc32(99)
     let walked = s0
     for (let i = 0; i < 7; i++) walked = nextState(walked)
     const jumped = stepState(7, s0)
-    expect(jumped.state).toStrictEqual(walked.state)
-    expect(jumped.streamId).toStrictEqual(walked.streamId)
+    assert.deepEqual(jumped.state, walked.state)
+    assert.deepEqual(jumped.streamId, walked.streamId)
   })
 
-  it('throws on negative delta because sfc32 is not reversible', () => {
-    expect.assertions(1)
-    expect(() => stepState(-1, createSfc32(1))).toThrow(RangeError)
+  test('throws on negative delta because sfc32 is not reversible', () => {
+    assert.throws(() => stepState(-1, createSfc32(1)), RangeError)
   })
 
-  it('survives JSON serialization round-trips', () => {
-    expect.assertions(1)
+  test('survives JSON serialization round-trips', () => {
     const pcg = createSfc32(42)
     const revived = JSON.parse(JSON.stringify(pcg)) as PCGState
     const rng = randomInt(0, 2 ** 32 - 1)
     const a = randomList(8, rng, pcg).map(([v]) => v)
     const b = randomList(8, rng, revived).map(([v]) => v)
-    expect(b).toStrictEqual(a)
+    assert.deepEqual(b, a)
   })
 
-  it('accepts bigint, number, and string seeds', () => {
-    expect.assertions(2)
+  test('accepts bigint, number, and string seeds', () => {
     const a = createSfc32(42)
     const b = createSfc32(42n)
     const c = createSfc32('42')
-    expect(b.state).toStrictEqual(a.state)
-    expect(c.state).toStrictEqual(a.state)
+    assert.deepEqual(b.state, a.state)
+    assert.deepEqual(c.state, a.state)
   })
 })

--- a/src/__tests__/stepState.test.ts
+++ b/src/__tests__/stepState.test.ts
@@ -1,8 +1,9 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createPcg32, nextState, stepState, randomInt } from '..'
 
 describe('stepState', () => {
-  it('can step forward multiple states', () => {
-    expect.assertions(1)
+  test('can step forward multiple states', () => {
     const random = randomInt(0, 2 ** 32 - 1)
     const s0 = createPcg32({}, 42, 54)
 
@@ -11,6 +12,6 @@ describe('stepState', () => {
     const s3 = nextState(s2)
     const s4 = nextState(s3)
     const q4 = stepState(4, s0)
-    expect(random(s4)[0]).toBe(random(q4)[0])
+    assert.equal(random(s4)[0], random(q4)[0])
   })
 })

--- a/src/__tests__/uint64.test.ts
+++ b/src/__tests__/uint64.test.ts
@@ -1,3 +1,5 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { add64, fromNumber, mul64 } from '../uint64'
 import { Uint64 } from '../types'
 
@@ -13,52 +15,52 @@ const fromBig = (v: bigint): Uint64 => ({
 
 describe('uint64', () => {
   describe('fromNumber', () => {
-    it('encodes zero', () => {
-      expect(fromNumber(0)).toEqual({ hi: 0, lo: 0 })
+    test('encodes zero', () => {
+      assert.deepEqual(fromNumber(0), { hi: 0, lo: 0 })
     })
 
-    it('encodes small positive integers', () => {
-      expect(fromNumber(1)).toEqual({ hi: 0, lo: 1 })
-      expect(fromNumber(0x1234)).toEqual({ hi: 0, lo: 0x1234 })
+    test('encodes small positive integers', () => {
+      assert.deepEqual(fromNumber(1), { hi: 0, lo: 1 })
+      assert.deepEqual(fromNumber(0x1234), { hi: 0, lo: 0x1234 })
     })
 
-    it('encodes the 32-bit boundary', () => {
-      expect(fromNumber(0xffffffff)).toEqual({ hi: 0, lo: 0xffffffff })
-      expect(fromNumber(0x100000000)).toEqual({ hi: 1, lo: 0 })
+    test('encodes the 32-bit boundary', () => {
+      assert.deepEqual(fromNumber(0xffffffff), { hi: 0, lo: 0xffffffff })
+      assert.deepEqual(fromNumber(0x100000000), { hi: 1, lo: 0 })
     })
 
-    it("encodes -1 as the all-ones two's complement word", () => {
-      expect(fromNumber(-1)).toEqual({ hi: 0xffffffff, lo: 0xffffffff })
+    test("encodes -1 as the all-ones two's complement word", () => {
+      assert.deepEqual(fromNumber(-1), { hi: 0xffffffff, lo: 0xffffffff })
     })
 
-    it('encodes -2 correctly', () => {
-      expect(fromNumber(-2)).toEqual({ hi: 0xffffffff, lo: 0xfffffffe })
+    test('encodes -2 correctly', () => {
+      assert.deepEqual(fromNumber(-2), { hi: 0xffffffff, lo: 0xfffffffe })
     })
 
-    it('agrees with the BigInt two\'s-complement encoding for representable values', () => {
+    test("agrees with the BigInt two's-complement encoding for representable values", () => {
       const samples = [0, 1, 7, -1, -7, 0xffffffff, -0xffffffff, 0x100000000, -0x100000000]
       for (const n of samples) {
         const big = (BigInt(n) + (1n << 64n)) & MASK_64
-        expect(fromNumber(n)).toEqual(fromBig(big))
+        assert.deepEqual(fromNumber(n), fromBig(big))
       }
     })
   })
 
   describe('add64', () => {
-    it('adds without carry', () => {
-      expect(add64({ hi: 0, lo: 3 }, { hi: 0, lo: 4 })).toEqual({ hi: 0, lo: 7 })
+    test('adds without carry', () => {
+      assert.deepEqual(add64({ hi: 0, lo: 3 }, { hi: 0, lo: 4 }), { hi: 0, lo: 7 })
     })
 
-    it('propagates carry from lo to hi', () => {
-      expect(add64({ hi: 0, lo: 0xffffffff }, { hi: 0, lo: 1 })).toEqual({ hi: 1, lo: 0 })
+    test('propagates carry from lo to hi', () => {
+      assert.deepEqual(add64({ hi: 0, lo: 0xffffffff }, { hi: 0, lo: 1 }), { hi: 1, lo: 0 })
     })
 
-    it('wraps modulo 2^64', () => {
+    test('wraps modulo 2^64', () => {
       const allOnes = { hi: 0xffffffff, lo: 0xffffffff }
-      expect(add64(allOnes, { hi: 0, lo: 1 })).toEqual({ hi: 0, lo: 0 })
+      assert.deepEqual(add64(allOnes, { hi: 0, lo: 1 }), { hi: 0, lo: 0 })
     })
 
-    it('matches BigInt addition over a sweep', () => {
+    test('matches BigInt addition over a sweep', () => {
       const samples: bigint[] = [
         0n,
         1n,
@@ -72,30 +74,30 @@ describe('uint64', () => {
       for (const a of samples) {
         for (const b of samples) {
           const expected = fromBig((a + b) & MASK_64)
-          expect(add64(fromBig(a), fromBig(b))).toEqual(expected)
+          assert.deepEqual(add64(fromBig(a), fromBig(b)), expected)
         }
       }
     })
   })
 
   describe('mul64', () => {
-    it('multiplies small values', () => {
-      expect(mul64({ hi: 0, lo: 3 }, { hi: 0, lo: 4 })).toEqual({ hi: 0, lo: 12 })
+    test('multiplies small values', () => {
+      assert.deepEqual(mul64({ hi: 0, lo: 3 }, { hi: 0, lo: 4 }), { hi: 0, lo: 12 })
     })
 
-    it('produces carry into the hi half', () => {
+    test('produces carry into the hi half', () => {
       const a = fromBig(0xffffffffn)
       const b = fromBig(0xffffffffn)
-      expect(mul64(a, b)).toEqual(fromBig((0xffffffffn * 0xffffffffn) & MASK_64))
+      assert.deepEqual(mul64(a, b), fromBig((0xffffffffn * 0xffffffffn) & MASK_64))
     })
 
-    it('wraps modulo 2^64', () => {
+    test('wraps modulo 2^64', () => {
       const a = fromBig(MASK_64)
       const b = fromBig(MASK_64)
-      expect(mul64(a, b)).toEqual(fromBig((MASK_64 * MASK_64) & MASK_64))
+      assert.deepEqual(mul64(a, b), fromBig((MASK_64 * MASK_64) & MASK_64))
     })
 
-    it('matches BigInt multiplication for the PCG multiplier constants', () => {
+    test('matches BigInt multiplication for the PCG multiplier constants', () => {
       const samples: bigint[] = [
         0n,
         1n,
@@ -108,12 +110,12 @@ describe('uint64', () => {
       for (const a of samples) {
         for (const b of samples) {
           const expected = fromBig((a * b) & MASK_64)
-          expect(mul64(fromBig(a), fromBig(b))).toEqual(expected)
+          assert.deepEqual(mul64(fromBig(a), fromBig(b)), expected)
         }
       }
     })
 
-    it('matches BigInt for a pseudo-random sweep', () => {
+    test('matches BigInt for a pseudo-random sweep', () => {
       // Self-contained pseudo-random sweep so we don't depend on the module
       // under test to drive its own correctness check.
       let s = 0x9e3779b97f4a7c15n
@@ -125,7 +127,7 @@ describe('uint64', () => {
         const a = next()
         const b = next()
         const expected = fromBig((a * b) & MASK_64)
-        expect(mul64(fromBig(a), fromBig(b))).toEqual(expected)
+        assert.deepEqual(mul64(fromBig(a), fromBig(b)), expected)
       }
     })
   })

--- a/src/__tests__/variant.test.ts
+++ b/src/__tests__/variant.test.ts
@@ -1,39 +1,36 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createPcg, createPcg32, nextState, randomInt } from '..'
 
 describe('PCGVariant tag', () => {
-  it('stamps new state objects with variant: "pcg32"', () => {
-    expect.assertions(1)
+  test('stamps new state objects with variant: "pcg32"', () => {
     const pcg = createPcg({}, 42, 54)
-    expect(pcg.variant).toBe('pcg32')
+    assert.equal(pcg.variant, 'pcg32')
   })
 
-  it('preserves the variant tag across nextState', () => {
-    expect.assertions(1)
+  test('preserves the variant tag across nextState', () => {
     let pcg = createPcg({}, 42, 54)
     for (let i = 0; i < 10; i++) pcg = nextState(pcg)
-    expect(pcg.variant).toBe('pcg32')
+    assert.equal(pcg.variant, 'pcg32')
   })
 
-  it('preserves the variant tag across JSON round-trips', () => {
-    expect.assertions(1)
+  test('preserves the variant tag across JSON round-trips', () => {
     const pcg = createPcg({}, 42, 54)
     const revived = JSON.parse(JSON.stringify(pcg))
-    expect(revived.variant).toBe('pcg32')
+    assert.equal(revived.variant, 'pcg32')
   })
 })
 
 describe('createPcg alias', () => {
-  it('createPcg is the same function as createPcg32', () => {
-    expect.assertions(1)
-    expect(createPcg).toBe(createPcg32)
+  test('createPcg is the same function as createPcg32', () => {
+    assert.equal(createPcg, createPcg32)
   })
 
-  it('createPcg and createPcg32 produce identical state for the same seed', () => {
-    expect.assertions(2)
+  test('createPcg and createPcg32 produce identical state for the same seed', () => {
     const a = createPcg({}, 42, 54)
     const b = createPcg32({}, 42, 54)
-    expect(b).toEqual(a)
+    assert.deepEqual(b, a)
     const rng = randomInt(0, 2 ** 32 - 1)
-    expect(rng(b)[0]).toBe(rng(a)[0])
+    assert.equal(rng(b)[0], rng(a)[0])
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "ignoreDeprecations": "6.0",
-    "types": ["jest", "node"]
+    "types": ["node"]
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
## Summary

- Rewrites all 14 test files in `src/__tests__/` to use node's built-in `node:test` runner and `node:assert/strict` instead of jest's `describe`/`it`/`expect` API.
- Drops `jest`, `ts-jest`, `@types/jest`, and `eslint-plugin-jest`. Adds `tsx` (for TS support at runtime via `node --import tsx --test`) and `@types/node` directly (it was previously pulled in transitively through `@types/jest`).
- Updates `package.json` scripts to use `node --test`, removes the `jest` config block, and updates `tsconfig.json` / `eslint.config.js` accordingly.

Mapping used:
- `expect(x).toBe(y)` → `assert.equal(x, y)`
- `expect(x).toEqual(y)` / `.toStrictEqual(y)` → `assert.deepEqual(x, y)`
- `expect(() => …).toThrow(Err)` → `assert.throws(() => …, Err)`
- `expect.assertions(n)` dropped — not idiomatic in `node:test`.
- `it.each([...])('name %s', fn)` → plain `for…of` loops around `test()`.

All 88 tests pass under `npm test` and the build + lint remain clean.

## Test plan
- [x] `npm test` — 88 passed
- [x] `npm run build` — clean
- [x] `npm run lint` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_014xVDAkyYkf7cqTu8q6rGKd)_