### PR TITLE
Expand Node test matrix to cover Node 12-24

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 18.x
+          - 20.x
           - 22.x
           - 24.x
     steps:
@@ -30,9 +32,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 12.x
+          - 14.x
           - 16.x
-          - 18.x
-          - 20.x
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A functional typescript implementation of the PCG family random number generators",
   "sideEffects": false,
   "engines": {
-    "node": ">=16"
+    "node": ">=12"
   },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -34,9 +34,9 @@
     "build": "tsup",
     "lint": "eslint src",
     "prepare": "husky install && npm run build",
-    "test": "node --import tsx --test 'src/__tests__/*.test.ts'",
-    "test:coverage": "mkdir -p coverage && node --import tsx --test --experimental-test-coverage --test-coverage-exclude='src/__tests__/**' --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info 'src/__tests__/*.test.ts'",
-    "test:watch": "node --import tsx --test --watch 'src/__tests__/*.test.ts'"
+    "test": "node --import tsx --test src/__tests__/*.test.ts",
+    "test:coverage": "mkdir -p coverage && node --import tsx --test --experimental-test-coverage --test-coverage-exclude='src/__tests__/**' --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info src/__tests__/*.test.ts",
+    "test:watch": "node --import tsx --test --watch src/__tests__/*.test.ts"
   },
   "devDependencies": {
     "@eslint/js": "9.39.4",


### PR DESCRIPTION
## Summary

Locally tested the library against every Node major from 10 through 24. Results:

| Node | CJS smoke | ESM smoke | `npm test` |
|------|-----------|-----------|------------|
| 10.x | ✅ | ❌ (Node 10's experimental ESM doesn't resolve our conditional exports) | n/a |
| 12.x | ✅ | ✅ | ❌ (no `node:test`) |
| 14.x | ✅ | ✅ | ❌ |
| 16.x | ✅ | ✅ | ❌ |
| 18.x | ✅ | ✅ | ✅ |
| 20.x | ✅ | ✅ | ✅ |
| 22.x | ✅ | ✅ | ✅ |
| 24.x | ✅ | ✅ | ✅ |

Changes:
- **Workflow matrix**:
  - `tests` (full `npm test` + lint): 18.x, 20.x, 22.x, 24.x (was 22.x, 24.x)
  - `compat` (CJS/ESM smoke against built dist): 12.x, 14.x, 16.x (was 16.x, 18.x, 20.x, now covered by `tests`)
- **`npm test` / `test:coverage` / `test:watch`**: drop the single quotes around the test glob so the shell expands it. Without this, the scripts only ran on Node 21+, where Node's `--test` flag does the glob expansion itself.
- **`engines.node`**: `>=16` → `>=12`, matching the lowest Node where both CJS and ESM entry points work.

Node 10 is dropped because its experimental ESM loader can't resolve the package's conditional `exports`, so the `.mjs` entry point doesn't load — there's no workaround short of removing the conditional exports map, which isn't worth it for an EOL runtime.

## Test plan
- [x] `npm test` passes on Node 18.20, 20.20, 22.22, 24.15
- [x] CJS + ESM smoke tests pass on Node 12.22, 14.21, 16.20
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test:coverage` produces `coverage/lcov.info`


---
_Generated by [Claude Code](https://claude.ai/code/session_014xVDAkyYkf7cqTu8q6rGKd)_