### PR TITLE
chore: release as 3.0.0 (Node 16 drop is breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 2.1.0
+## 3.0.0
+
+### Breaking changes
+
+- **Minimum Node.js version raised from `>=16` to `>=18`.** Node 16 has
+  been EOL since September 2023; Node 18 is the lowest line still in any
+  kind of common deployment. Consumers on Node 16 should stay on 2.x.
 
 ### Features
 
@@ -20,9 +26,6 @@
 - Migrated the test suite from `jest` to the built-in `node:test` runner
   (#342). No behavior change for consumers; dev iteration is faster and
   the dependency footprint shrinks.
-- Minimum Node.js version raised from `>=16` to `>=18`. Node 16 has been
-  EOL since September 2023; Node 18 is the lowest line still in any kind
-  of common deployment.
 - Dropped unused `husky` / `lint-staged` dev dependencies. Linting still
   runs in CI.
 - Pinned `@types/node` to `^24` to match the `@tsconfig/node24` base.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcg",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "A functional typescript implementation of the PCG family random number generators",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

The next release should be **3.0.0**, not 2.1.0.

The unreleased work raises `engines.node` from `>=16` to `>=18`. The v2.0.0 changelog entry already established that raising the Node floor is a breaking change for this project ("Minimum Node.js version is now 16." was listed under **Breaking changes** there), so this release should follow the same convention. Bumping `engines` can cause silent install failures for downstream consumers — exactly what a semver-major signal exists for.

The rest of the diff (mulberry32, sfc32, `createPcg` alias, jest → node:test, dropped husky, pinned `@types/node`) is additive or dev-only and would be a clean minor on its own — but you only get to telegraph "Node 16 is gone" once, so it should ride along with the major.

### Changes

- `package.json`: `2.0.0` → `3.0.0`
- `CHANGELOG.md`: renamed `## 2.1.0` to `## 3.0.0` and promoted the Node engines bump out of "Tooling" into a new "Breaking changes" section, with a note that Node 16 consumers should stay on 2.x.

### Alternative if you'd rather not cut a major yet

Revert the `engines.node` change back to `>=16` on `main`, release the additive features as `2.1.0`, and batch the Node floor bump into a future `3.0.0` with anything else breaking you've been holding back. Happy to prep that variant instead — say the word.

## Test plan

- [ ] Confirm 3.0.0 is the intended next version (vs. deferring the engines bump and shipping 2.1.0)
- [ ] CI green on Node 18/20/22/24
- [ ] `npm run build` produces dist/ as expected


---
_Generated by [Claude Code](https://claude.ai/code/session_01G2zXncDC862LeLHL5iUGLL)_