### PR TITLE
docs: improve discoverability via keywords, tagline, runtimes note

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A functional implementation of the [PCG family random number generators](http://
 npm install pcg
 ```
 
-The package ships dual ESM/CJS builds and TypeScript types. **Runs on Node 18+, Bun, Deno, and modern browsers.**
+The package ships dual ESM/CJS builds and TypeScript types. Runs on Node 18+, Bun, Deno, and modern browsers.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # pcg
 
+> Seeded, deterministic PRNG for JavaScript & TypeScript — PCG32, mulberry32, sfc32. Same seed, same sequence.
+
 [![Version](https://img.shields.io/npm/v/pcg.svg)](https://www.npmjs.com/package/pcg)
 [![Tests](https://github.com/philihp/pcg/actions/workflows/tests.yml/badge.svg)](https://github.com/philihp/pcg/actions/workflows/tests.yml)
 [![Coverage](https://coveralls.io/repos/github/philihp/pcg/badge.svg?branch=main)](https://coveralls.io/github/philihp/pcg?branch=main)
+[![Bundle size](https://img.shields.io/bundlephobia/minzip/pcg)](https://bundlephobia.com/package/pcg)
 ![Downloads](https://img.shields.io/npm/dm/pcg)
 ![License](https://img.shields.io/npm/l/pcg)
 
@@ -14,7 +17,7 @@ A functional implementation of the [PCG family random number generators](http://
 npm install pcg
 ```
 
-The package ships dual ESM/CJS builds and TypeScript types.
+The package ships dual ESM/CJS builds and TypeScript types. **Runs on Node 18+, Bun, Deno, and modern browsers.**
 
 ## Quick start
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,20 @@
   "name": "pcg",
   "version": "3.0.0",
   "description": "A functional typescript implementation of the PCG family random number generators",
+  "keywords": [
+    "prng",
+    "rng",
+    "random",
+    "seeded",
+    "seedable",
+    "deterministic",
+    "reproducible",
+    "pcg",
+    "sfc32",
+    "mulberry32"
+  ],
+  "homepage": "https://github.com/philihp/pcg#readme",
+  "bugs": "https://github.com/philihp/pcg/issues",
   "type": "module",
   "sideEffects": false,
   "engines": {


### PR DESCRIPTION
## Summary

Make `pcg` easier to find for people searching npm/Google for "seeded random", "deterministic PRNG", or "alternative to seedrandom". Two root causes addressed:

1. **`package.json` had no `keywords` field at all** — npm search ranks heavily on this. Adds the 10 most relevant terms plus `homepage` and `bugs`.
2. **README's first heading + paragraph led with PCG-family jargon** — the search-relevant terms ("seeded", "deterministic", "PCG32 / mulberry32 / sfc32") were buried. Adds a one-line tagline blockquote directly under the H1 so they appear above the fold without disturbing the existing intro paragraph.

Also adds a bundle-size badge (clicks-driver for people picking a small lib) and an explicit runtimes line (each is a search term: Node, Bun, Deno, browsers).

The `description` field is intentionally **unchanged** per the maintainer's preference.

### Out of scope (left for the maintainer to do manually, since they can't go through a PR)
- Set GitHub repo topics (Settings → "About"): `prng`, `random`, `seeded-random`, `deterministic`, `pcg`, `mulberry32`, `sfc32`, `typescript`, `nodejs`. Topics drive GitHub's own search and the topic landing pages.
- Update the repo "About" blurb on github.com to match what's on npm.

## Test plan

- [ ] Render the README on the PR page and confirm the tagline + new badge display correctly
- [ ] Run `npm pkg get keywords homepage bugs` and confirm the new values
- [ ] After merge & publish, search npm for "seeded random" / "deterministic prng" and confirm `pcg` ranks higher than before


---
_Generated by [Claude Code](https://claude.ai/code/session_01G2zXncDC862LeLHL5iUGLL)_