### PR TITLE
Fix implementation of randomUint32 in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import { createPcg32, nextState, randomInt, randomList } from 'pcg'
 // The seed picks *where* in that series to start.
 const state0 = createPcg32({}, 42, 54)
 
-const randomUint32 = randomInt(0, 2 ** 32 - 1)
+const randomUint32 = randomInt(0, 2 ** 32)
 const [value, state1] = randomUint32(state0)
 
 const list = randomList(3, randomUint32, state0)


### PR DESCRIPTION
The incorrect implementation `randomUint32 = randomInt(0, 2 ** 32 - 1)` returns a random uint other than 2 ** 32 - 1, because the output of randomInt is in [min, max). The correct implementation is `randomInt(0, 2 ** 32)`. The mistake is only in the README, and not in the library code.