### PR TITLE
ci: unbork Coveralls upload step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
       - run: npm run build --if-present
       - run: npm run test:coverage
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage/lcov.info
+          format: lcov


### PR DESCRIPTION
## Summary
- Pin `coverallsapp/github-action` from `@master` to `@v2` so the coverage upload step resolves to a known release
- Pass `file: coverage/lcov.info` and `format: lcov` explicitly so the action picks up the report produced by `npm run test:coverage`

## Test plan
- [ ] CI `coverage` job runs to completion and uploads to Coveralls

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvdY335BJG7Nkr3g5643kN)_